### PR TITLE
Make compute_stats head-to-head cache payload pickleable

### DIFF
--- a/rank_polo.py
+++ b/rank_polo.py
@@ -76,7 +76,14 @@ def infer_default_scores(games_df, stats):
 @st.cache_data
 def compute_stats(games):
     stats = {}
-    h2h = defaultdict(lambda: {'wins': 0, 'games': 0, 'gf': 0, 'ga': 0})
+    h2h = {}
+
+    def ensure_h2h_record(me, opp):
+        key = (me, opp)
+        if key not in h2h:
+            h2h[key] = {'wins': 0, 'games': 0, 'gf': 0, 'ga': 0}
+        return h2h[key]
+
     teams = set(games['team1']).union(games['team2'])
     for t in teams:
         stats[t] = {'wins':0,'losses':0,'ties':0,'gf':0,'ga':0,'games':0,'opponents':[]}
@@ -87,15 +94,22 @@ def compute_stats(games):
             stats[me]['ga'] += os
             stats[me]['games'] += 1
             stats[me]['opponents'].append(opp)
-            h2h[(me,opp)]['gf'] += ms
-            h2h[(me,opp)]['ga'] += os
+            h2h_record = ensure_h2h_record(me, opp)
+            h2h_record['gf'] += ms
+            h2h_record['ga'] += os
         if s1>s2:
-            stats[t1]['wins']+=1; stats[t2]['losses']+=1; h2h[(t1,t2)]['wins']+=1
+            stats[t1]['wins']+=1
+            stats[t2]['losses']+=1
+            ensure_h2h_record(t1, t2)['wins']+=1
         elif s2>s1:
-            stats[t2]['wins']+=1; stats[t1]['losses']+=1; h2h[(t2,t1)]['wins']+=1
+            stats[t2]['wins']+=1
+            stats[t1]['losses']+=1
+            ensure_h2h_record(t2, t1)['wins']+=1
         else:
-            stats[t1]['ties']+=1; stats[t2]['ties']+=1
-        h2h[(t1,t2)]['games']+=1; h2h[(t2,t1)]['games']+=1
+            stats[t1]['ties']+=1
+            stats[t2]['ties']+=1
+        ensure_h2h_record(t1, t2)['games']+=1
+        ensure_h2h_record(t2, t1)['games']+=1
     for t,st in stats.items():
         tot=st['wins']+st['losses']+st['ties']
         st['win_pct']=st['wins']/tot if tot else 0


### PR DESCRIPTION
### Motivation
- The `compute_stats(games)` function returned a `defaultdict` with a lambda factory which is not pickleable and caused `@st.cache_data` to store non-pickleable payloads.
- Convert head-to-head storage to a plain, pickleable structure so cached results can be serialized safely.

### Description
- Replaced `defaultdict(lambda: {...})` usage with a plain `dict` for `h2h` and added `ensure_h2h_record(me, opp)` to initialize records on first use.
- Updated every write to head-to-head entries to call `ensure_h2h_record(...)` before mutating fields (`gf`, `ga`, `wins`, `games`).
- Kept the function signature and caching decorator unchanged, returning `stats, h2h` (now a plain `dict`).
- Minor formatting adjustments to expand in-line statements into separate lines for clarity.

### Testing
- `python -m py_compile rank_polo.py` ran successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16ec04804832caf90817b8de8ea1e)