### PR TITLE
Make compute_sectional_rankings accept SOS explicitly

### DIFF
--- a/rank_polo.py
+++ b/rank_polo.py
@@ -209,8 +209,7 @@ def rank_elo(stats,elo):
     return sorted(stats.keys(),key=lambda t:elo[t],reverse=True)
 
 # ---------------- Sectional Rankings ---------------- #
-def compute_sectional_rankings(stats, h2h, games_inferred):
-    sos = compute_sos(stats)
+def compute_sectional_rankings(stats, h2h, games_inferred, sos):
     sectionals = {
         "Barrington": ["Hersey", "Barrington", "Elk Grove", "Conant", "Hoffman Estates", "McHenry", "Fremd", "Palatine", "Meadows", "Schaumburg"],
         "Chicago (Lane)": ["Amundsen", "Jones-Payton", "Kenwood", "Lane", "Latin", "Senn", "St Ignatius", "Whitney Young"],
@@ -455,7 +454,7 @@ def main():
     elo = compute_elo(games_inferred)
     
     # Compute sectional rankings
-    sectional_rankings, sectional_order = compute_sectional_rankings(stats, h2h, games_inferred)
+    sectional_rankings, sectional_order = compute_sectional_rankings(stats, h2h, games_inferred, sos)
     
     # Orders & filters
     win_ord = rank_win_pct(stats,h2h)


### PR DESCRIPTION
### Motivation
- Remove the hidden dependency on an outer-scope `sos` recomputation so `compute_sectional_rankings` becomes pure and receives its SOS data explicitly.

### Description
- Changed the signature from `def compute_sectional_rankings(stats, h2h, games_inferred):` to `def compute_sectional_rankings(stats, h2h, games_inferred, sos)` and removed the internal `compute_sos(stats)` call.
- Updated the `main()` call site to pass the precomputed `sos` via `compute_sectional_rankings(stats, h2h, games_inferred, sos)` and ensured all `sos[...]` uses inside the function refer to the passed parameter.

### Testing
- Ran code searches to verify the signature and all `sos[...]` references were updated and resolved to the new parameter, and the checks passed.
- Verified the file diff to confirm only the intended lines were changed and no ranking formulas were altered, and the diff inspection passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1708c0248832c9bec4734afbcea18)