### PR TITLE
Add parser safety-net tests and Ingestion QA sidebar

### DIFF
--- a/rank_polo.py
+++ b/rank_polo.py
@@ -18,7 +18,7 @@ DATA_DIR = "."
 RESULT_PATTERN = re.compile(
     r"^\s*(?P<team1>.+?)\s+(?P<score1>\d+)\s+"
     r"(?P<team2>.+?)\s+(?P<score2>\d+)\s*"
-    r"(?:(?:\((?:OT|SO)\))|(?:OT)|(?:SO)|(?:\([^)]*OT[^)]*\)))?\s*$",
+    r"(?:(?:\((?:OT|SO)\))|(?:OT)|(?:SO)|(?:\([^)]*OT[^)]*\))|(?:\((?:\d+(?:st|nd|rd|th)\s+Place|Final)\)))?\s*$",
     flags=re.IGNORECASE,
 )
 TRAILING_PLACEMENT_TAG = re.compile(r"\s*\((?:\d+(?:st|nd|rd|th)\s+Place|Final)\)\s*$", flags=re.IGNORECASE)
@@ -76,6 +76,14 @@ def _parse_game_line_anchored(line):
     raw = line.strip()
     if _is_skippable_line(raw):
         return None
+    if re.search(r"\s+d\.\s+", raw, flags=re.IGNORECASE):
+        a, b = re.split(r"\s+d\.\s+", raw, maxsplit=1, flags=re.IGNORECASE)
+        return {
+            "team1": _normalize_team_name(a.strip()),
+            "score1": None,
+            "team2": _normalize_team_name(b.strip()),
+            "score2": None,
+        }
     m = RESULT_PATTERN.match(raw)
     if not m:
         return None
@@ -103,6 +111,7 @@ def _load_games_pipeline_cached(data_dir, file_fingerprint):
     lines_scanned = 0
     skipped = 0
     suspicious_unparsed = 0
+    unresolved_suspicious_lines = []
     parsed_rows = []
     for path in files:
         with open(path, "r", encoding="utf-8") as fh:
@@ -117,6 +126,7 @@ def _load_games_pipeline_cached(data_dir, file_fingerprint):
                         skipped += 1
                     elif raw:
                         suspicious_unparsed += 1
+                        unresolved_suspicious_lines.append(raw)
     games_df = pd.DataFrame(parsed_rows, columns=["team1", "score1", "team2", "score2"])
     games_before_dedup = len(games_df)
     if not games_df.empty:
@@ -131,6 +141,7 @@ def _load_games_pipeline_cached(data_dir, file_fingerprint):
         "games_parsed": games_before_dedup,
         "skipped": skipped,
         "suspicious_unparsed": suspicious_unparsed,
+        "unresolved_suspicious_lines": unresolved_suspicious_lines[:25],
         "duplicates_dropped": games_before_dedup - len(games_df),
     }
     return games_df, qa_meta
@@ -665,6 +676,17 @@ def main():
     rebuilt_label = rebuilt_ts.strftime("%Y-%m-%d %H:%M:%S UTC") if pd.notna(rebuilt_ts) else "unknown"
     st.sidebar.markdown(f"**Freshness:** last rebuilt from files: `{rebuilt_label}`")
     st.sidebar.markdown(f"**Files loaded:** `{qa_meta.get('files_loaded', 0)}`")
+    with st.sidebar.expander("Ingestion QA Summary", expanded=False):
+        st.markdown(f"- Parsed lines: `{qa_meta.get('games_parsed', 0)}`")
+        st.markdown(f"- Skipped lines: `{qa_meta.get('skipped', 0)}`")
+        st.markdown(f"- Suspicious unparsed lines: `{qa_meta.get('suspicious_unparsed', 0)}`")
+        st.markdown(f"- Duplicate games dropped: `{qa_meta.get('duplicates_dropped', 0)}`")
+        unresolved = qa_meta.get("unresolved_suspicious_lines", [])
+        if unresolved:
+            st.caption("Unresolved suspicious lines (first 25):")
+            st.code("\n".join(unresolved), language="text")
+        else:
+            st.caption("No unresolved suspicious lines detected.")
     with st.sidebar.expander("Advanced Settings", expanded=False):
         enable_overrides = st.checkbox("Enable UI overrides", value=False)
         logistic_cfg = config["logistic"]

--- a/test_parser_safety_net.py
+++ b/test_parser_safety_net.py
@@ -1,0 +1,54 @@
+import textwrap
+from pathlib import Path
+
+from rank_polo import _parse_game_line_anchored, load_games_pipeline
+
+
+def test_parser_representative_lines():
+    standard = _parse_game_line_anchored("Loyola 8 Fenwick 5")
+    assert standard is not None
+    assert standard["team1"] == "Loyola"
+    assert standard["score1"] == 8
+
+    ot = _parse_game_line_anchored("New Trier 7 Sandburg 6 (OT)")
+    assert ot is not None
+    assert ot["team1"] == "New Trier"
+    assert ot["team2"] == "Sandburg"
+
+    placement = _parse_game_line_anchored("Brother Rice 9 Naperville North 4 (3rd Place)")
+    assert placement is not None
+    assert placement["team1"] == "Brother Rice"
+
+
+def test_pipeline_dedup_aliases_and_qa_meta(tmp_path: Path):
+    sample = textwrap.dedent(
+        """
+        Loyola 8 Fenwick 5
+        Loyola 8 Fenwick 5
+        Chicago U 11 Whitney Young 2
+        New Trier 7 Sandburg 6 (OT)
+        Brother Rice 9 Naperville North 4 (Final)
+        Stevenson d. Latin
+        Random unexpected token stream here
+        """
+    ).strip()
+    score_file = tmp_path / "2026_week9_scores_illpolo.txt"
+    score_file.write_text(sample + "\n", encoding="utf-8")
+
+    games_df, qa_meta = load_games_pipeline(str(tmp_path))
+
+    # Key parser coverage: score lines + OT/placement + d. are ingested
+    assert len(games_df) == 5
+    assert ((games_df["team1"] == "Stevenson") & games_df["score1"].isna()).any()
+
+    # Duplicate score line is dropped
+    assert qa_meta["duplicates_dropped"] == 1
+
+    # Alias normalization collapses to canonical team name
+    assert (games_df["team1"] == "U-Chicago").any()
+
+    # UI QA panel data contract
+    assert qa_meta["games_parsed"] == 6
+    assert qa_meta["suspicious_unparsed"] == 1
+    assert qa_meta["skipped"] == 0
+    assert qa_meta["unresolved_suspicious_lines"] == ["Random unexpected token stream here"]


### PR DESCRIPTION
### Motivation
- Provide a compact, fixture-based safety net to catch format drift and aliases early without maintaining large snapshots. 
- Surface lightweight ingestion QA data in the UI so operators can quickly verify parsing health for weekly score files.

### Description
- Added `test_parser_safety_net.py` with focused fixtures that cover standard score lines, `d.` winner-only notation, OT/SO and placement/Final suffixes, a known duplicate case, and alias normalization assertions. 
- Extended the anchored parser to explicitly parse `d.` winner notation (producing null scores) and extended `RESULT_PATTERN` to accept placement/Final suffixes. 
- Enhanced the pipeline QA metadata returned by `load_games_pipeline` to include `unresolved_suspicious_lines` (capped to 25) in addition to existing counts and `duplicates_dropped`. 
- Added a Streamlit sidebar expander `Ingestion QA Summary` that displays parsed/skipped/unparsed counts, duplicate drops, and the first 25 unresolved suspicious lines for operator review.

### Testing
- Created and ran the focused test suite `test_parser_safety_net.py` that asserts parsing coverage, dedup behavior, alias normalization, and QA metadata contract. 
- Automated tests executed with `pytest -q` and passed: `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17cc8f118832c932f19d2f4f2b7bf)