### PR TITLE
Fix undefined uploader reference in Streamlit tab

### DIFF
--- a/rank_polo.py
+++ b/rank_polo.py
@@ -1024,6 +1024,7 @@ def main():
 
     with tabs[7]:
         st.subheader("What changed since last upload")
+        uploader = st.session_state.get("uploader")
         if uploader and not prior_games.empty:
             prev_stats, prev_h2h = compute_stats(infer_default_scores(prior_games, compute_stats(prior_games.dropna(subset=["score1"]))[0]))
             prev_py = compute_pythag(infer_default_scores(prior_games, prev_stats), prev_stats, exp=pythag_exp, imputed_mode=imputed_mode, imputed_weight=imputed_weight)


### PR DESCRIPTION
## Summary
- prevent a `NameError` in `rank_polo.py` by defining `uploader` from Streamlit session state before it is checked
- keep the existing `if uploader and not prior_games.empty` logic intact

## Root Cause
The code referenced `uploader` in the "What changed since last upload" tab, but no local or global variable with that name was defined in the current app flow.

## Validation
- Static inspection confirms `uploader` previously had exactly one reference and no definition.
- After the fix, the variable is always defined before use, so the page no longer crashes from this `NameError`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17d6203a8832c91518183ef12c5bd)