### PR TITLE
Cap Win% ensemble impact under weak-data conditions

### DIFF
--- a/model_config.json
+++ b/model_config.json
@@ -15,8 +15,8 @@
   },
   "ensemble_weights": {
     "Elo": 0.45,
-    "Pyth": 0.30,
-    "AdjPyth": 0.20,
+    "Pyth": 0.3,
+    "AdjPyth": 0.2,
     "Win": 0.05
   },
   "sectional": {
@@ -26,7 +26,7 @@
     "sectional_penalty_threshold": 0.7,
     "h2h_weight": 0.45,
     "common_weight": 0.45,
-    "win_pct_weight": 0.10,
+    "win_pct_weight": 0.1,
     "sos_center": 0.5,
     "sos_scale": 2.0,
     "sectional_sos_boost": 1.1,
@@ -39,5 +39,10 @@
     "global_prior_min_weight": 0.1,
     "global_prior_max_weight": 0.25,
     "global_prior_shrink_k": 4.0
+  },
+  "win_model_cap": {
+    "max_multiplier": 0.85,
+    "coverage_floor": 0.65,
+    "imputation_ceiling": 0.3
   }
 }

--- a/rank_polo.py
+++ b/rank_polo.py
@@ -779,7 +779,7 @@ def compute_rank_tie_break_key(team, stats, sos, h2h):
     stable_secondary = stats[team]["win_pct"]
     return (direct_h2h_win_pct, sos_adjusted_margin, stable_secondary)
 
-def build_calibrated_ensemble(teams, orders, stats, h2h, sos, team_imputation, ensemble_base_weights=None):
+def build_calibrated_ensemble(teams, orders, stats, h2h, sos, team_imputation, ensemble_base_weights=None, win_model_cap=None):
     base_weights = ensemble_base_weights or {
         "Elo": 0.45,
         "Pyth": 0.30,
@@ -802,6 +802,14 @@ def build_calibrated_ensemble(teams, orders, stats, h2h, sos, team_imputation, e
             model: base_weights[model] * reliability * reliability_modulators[model]
             for model in base_weights
         }
+        win_cap_cfg = win_model_cap or {}
+        win_cap_max = float(win_cap_cfg.get("max_multiplier", 0.85))
+        win_cov_floor = float(win_cap_cfg.get("coverage_floor", 0.65))
+        win_imp_ceiling = float(win_cap_cfg.get("imputation_ceiling", 0.30))
+        cov_cap_ratio = min(1.0, coverage_ratio / max(win_cov_floor, 1e-9)) if win_cov_floor > 0 else 1.0
+        imp_cap_ratio = min(1.0, max(0.0, (1.0 - imp_ratio) / max(1.0 - win_imp_ceiling, 1e-9))) if win_imp_ceiling < 1.0 else 1.0
+        win_cap_multiplier = min(win_cap_max, cov_cap_ratio, imp_cap_ratio)
+        weights["Win"] *= max(0.0, min(1.0, win_cap_multiplier))
         total_weight = sum(weights.values())
         normalized_weights = {
             model: (weights[model] / total_weight) if total_weight else 0.0
@@ -862,6 +870,11 @@ def main():
         "AdjPyth": float(config.get("ensemble_weights", {}).get("AdjPyth", 0.20)),
         "Win": float(config.get("ensemble_weights", {}).get("Win", 0.05)),
     }
+    win_model_cap_cfg = config.get("win_model_cap", {
+        "max_multiplier": 0.85,
+        "coverage_floor": 0.65,
+        "imputation_ceiling": 0.30,
+    })
 
     # Sidebar settings
     st.sidebar.header("Data & Model Settings")
@@ -964,6 +977,7 @@ def main():
 
     with st.sidebar.expander("Model Settings", expanded=False):
         st.caption("Active model configuration for reproducibility")
+        st.caption("Win% is intentionally low-trust in composite scoring and receives an additional reliability cap in the ensemble.")
         st.json(active_config)
     
     # Initial stats
@@ -1007,7 +1021,7 @@ def main():
     teams    = sorted(stats.keys())
     model_orders = {"Win": win_ord, "Pyth": py_ord, "AdjPyth": adj_ord, "Elo": elo_ord}
     global_prior_teams = [t for t in teams if t in win_ord and t in py_ord and t in adj_ord and t in elo_ord]
-    global_prior_df = build_calibrated_ensemble(global_prior_teams, model_orders, stats, h2h, sos, team_imputation, ensemble_base_weights=ensemble_weights_cfg)
+    global_prior_df = build_calibrated_ensemble(global_prior_teams, model_orders, stats, h2h, sos, team_imputation, ensemble_base_weights=ensemble_weights_cfg, win_model_cap=win_model_cap_cfg)
     global_prior_scores = dict(zip(global_prior_df["Team"], global_prior_df["Calibrated Score"]))
 
     # Compute sectional rankings
@@ -1163,7 +1177,7 @@ def main():
     with tabs[5]:
         st.subheader("Rankings by Calibrated Ensemble")
         eligible_teams = [t for t in teams if stats[t]['games'] >= thr and t in win_ord and t in py_ord and t in adj_ord and t in elo_ord]
-        df_avg = build_calibrated_ensemble(eligible_teams, model_orders, stats, h2h, sos, team_imputation, ensemble_base_weights=ensemble_weights_cfg)
+        df_avg = build_calibrated_ensemble(eligible_teams, model_orders, stats, h2h, sos, team_imputation, ensemble_base_weights=ensemble_weights_cfg, win_model_cap=win_model_cap_cfg)
         st.dataframe(df_avg[[
             "Rank", "Team", "Calibrated Score", "Ordinal Avg (Debug)", "Direct H2H Tiebreak", "SOS Margin Tiebreak", "Stable Secondary"
         ]])


### PR DESCRIPTION
### Motivation
- Win% should remain unchanged for standalone display but be treated as lower-trust when blended into the ensemble under weak-data conditions. 
- Provide a tunable, configuration-driven cap so the Win% contribution can be reduced when schedule coverage is low or imputation rate is high. 

### Description
- Left `rank_win_pct` unchanged and introduced an ensemble-only `win_model_cap` parameter to `build_calibrated_ensemble(...)` to limit Win% contribution after base/reliability weighting and before normalization. 
- Added `win_model_cap` to `model_config.json` with keys `max_multiplier`, `coverage_floor`, and `imputation_ceiling` and wired config loading into `main()` as `win_model_cap_cfg`. 
- Applied the cap by computing a `win_cap_multiplier` (bounded by the configured `max_multiplier`, coverage ratio vs `coverage_floor`, and imputation vs `imputation_ceiling`) and multiplying `weights['Win']` prior to weight normalization. 
- Passed `win_model_cap` into both ensemble call sites (`global_prior_df` and the main Avg tab `build_calibrated_ensemble(...)`) and added a sidebar note in the `Model Settings` expander noting Win% is intentionally low-trust in composite scoring. 

### Testing
- Ran `python -m py_compile rank_polo.py` which completed successfully. 
- Verified the source diff and updated `model_config.json` were written and the change was committed successfully. 
- No automated unit tests exist for the ensemble path beyond compilation checks, and no compilation errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18af01978832c954bb780482cfac8)