### PR TITLE
Adjust shared-opponent weighting to curb inflated sectional rankings

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -570,13 +570,20 @@ def compute_shared_opponent_score(team, valid_teams, team_vectors, stats, p):
         games = rec["games"]
         total_games += games
         value = rec["win_rate"] if metric == "win_rate" else rec["margin_per_game"]
-        weighted_metric_sum += (value * games)
+        opp_strength = stats[opp]["win_pct"]
+        # Discount results against weak shared opponents so teams cannot
+        # inflate sectional placement purely by farming low-quality common foes.
+        strength_scale = min(max(opp_strength / 0.5, 0.6), 1.4)
+        adjusted_value = value * strength_scale if metric == "win_rate" else value
+        weighted_metric_sum += (adjusted_value * games)
         detail_rows.append({
             "Opponent": opp,
             "Record": f"{rec['wins']}-{rec['losses']}",
             "Games": games,
             "Win %": rec["win_rate"],
             "Margin/Game": rec["margin_per_game"],
+            "Opp Win %": opp_strength,
+            "Strength Scale": strength_scale,
             "Included Teams": sorted(opp_coverage.get(opp, [])),
         })
 


### PR DESCRIPTION
## Summary
- strength-adjust common-opponent win-rate scoring in `compute_shared_opponent_score`
- discount results against weak shared opponents and slightly reward strong-opponent results
- expose opponent strength and applied scale in breakdown details for transparency

## Why
Some teams were being overrated in sectional rankings when they had excellent records against weak common opponents. This change makes shared-opponent contribution quality-sensitive, which brings those teams closer to expected placement.

## Implementation details
- compute `opp_strength = stats[opp]["win_pct"]`
- derive `strength_scale` from opponent win% relative to neutral 0.5 (clamped to 0.6..1.4)
- apply the scale to win-rate metric before accumulating weighted shared-opponent score
- add `Opp Win %` and `Strength Scale` fields to detail rows

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18ffc5090832c868f281b1bbf6ad3)