### PR TITLE
Ensure base_stats includes all teams before inferring default scores

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -180,6 +180,10 @@ def compute_weekly_rank_history(data_dir=DATA_DIR):
             continue
         scored_games = week_games.dropna(subset=["score1"])
         base_stats, _ = compute_stats(scored_games)
+        all_week_teams = set(week_games["team1"]).union(set(week_games["team2"]))
+        for team in all_week_teams:
+            if team not in base_stats:
+                base_stats[team] = {'wins':0,'losses':0,'ties':0,'gf':0,'ga':0,'games':0,'opponents':[]}
         inferred = infer_default_scores(week_games, base_stats)
         week_stats, week_h2h = compute_stats(inferred)
         week_order = rank_win_pct(week_stats, week_h2h)


### PR DESCRIPTION
### Motivation
- Prevent `KeyError` in `infer_default_scores` when weekly files contain placeholder `d.` games or teams with no scored games by guaranteeing every team in `week_games` has an entry in `base_stats`.

### Description
- In `compute_weekly_rank_history` (in `app/ui.py`), after `base_stats, _ = compute_stats(scored_games)` build `all_week_teams = set(week_games["team1"]).union(set(week_games["team2"]))` and initialize any missing `base_stats[team] = {'wins':0,'losses':0,'ties':0,'gf':0,'ga':0,'games':0,'opponents':[]}` before calling `infer_default_scores(week_games, base_stats)`, leaving `infer_default_scores` logic unchanged.

### Testing
- Executed `compute_weekly_rank_history('.')` against the dataset including sparse/dotted-notation games and confirmed it completed successfully with rank rows produced and no `KeyError`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1927609d4832cbf4d5039c6ea9621)