### PR TITLE
Refactor parser into configurable rule pipeline

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -10,22 +10,13 @@ from functools import cmp_to_key
 import streamlit as st
 import altair as alt
 
+from domain.parsing import discover_score_files, is_skippable_line, load_parser_config, normalize_team_name, parse_game_line_anchored
+
 # ---------------- Constants ---------------- #
 SCORES_CSV = "scores.csv"
 CONFIG_JSON = "model_config.json"
 SCORES_GLOB_SUFFIX = "_scores_illpolo.txt"
 DATA_DIR = "."
-RESULT_PATTERN = re.compile(
-    r"^\s*(?P<team1>.+?)\s+(?P<score1>\d+)\s+"
-    r"(?P<team2>.+?)\s+(?P<score2>\d+)\s*"
-    r"(?:(?:\((?:OT|SO)\))|(?:OT)|(?:SO)|(?:\([^)]*OT[^)]*\))|(?:\((?:\d+(?:st|nd|rd|th)\s+Place|Final)\)))?\s*$",
-    flags=re.IGNORECASE,
-)
-TRAILING_PLACEMENT_TAG = re.compile(r"\s*\((?:\d+(?:st|nd|rd|th)\s+Place|Final)\)\s*$", flags=re.IGNORECASE)
-TEAM_ALIASES = {
-    "chicago u": "U-Chicago",
-    "chicago-u": "U-Chicago",
-}
 SEMANTIC_COLORS = {
     "positive": "#2E8540",
     "negative": "#B50909",
@@ -34,72 +25,20 @@ SEMANTIC_COLORS = {
 
 # ---------------- Parsing ---------------- #
 def _parse_line(line):
-    games = []
-    raw = line.strip()
-    if not raw or raw.lower().startswith("championship") or " vs " in raw.lower():
-        return games
-    # Default win notation "d." => placeholder None scores
-    if re.search(r"\s+d\.\s+", raw, flags=re.IGNORECASE):
-        a, b = re.split(r"\s+d\.\s+", raw, maxsplit=1, flags=re.IGNORECASE)
-        games.append({"team1": a.strip(), "score1": None, "team2": b.strip(), "score2": None})
-        return games
-    m = RESULT_PATTERN.match(raw)
-    if m:
-        t1 = _normalize_team_name(m.group("team1"))
-        s1 = int(m.group("score1"))
-        t2 = _normalize_team_name(m.group("team2"))
-        s2 = int(m.group("score2"))
-        games.append({"team1": t1, "score1": s1, "team2": t2, "score2": s2})
-    return games
+    parsed = _parse_game_line_anchored(line)
+    return [parsed] if parsed is not None else []
 
 def _is_skippable_line(raw):
-    lowered = raw.lower().strip()
-    if not lowered:
-        return True
-    if re.fullmatch(r"[-=_.\s]+", raw):
-        return True
-    if " vs " in lowered:
-        return True
-    if lowered.startswith(("schedule", "championship", "tournament", "results", "bracket")):
-        return True
-    if "illinois high school polo association" in lowered or "ihspa" in lowered:
-        return True
-    if lowered.endswith(":"):
-        return True
-    return False
+    return is_skippable_line(raw)
 
 def _normalize_team_name(name):
-    cleaned = TRAILING_PLACEMENT_TAG.sub("", name).strip()
-    canonical = TEAM_ALIASES.get(cleaned.lower())
-    return canonical if canonical else cleaned
+    return normalize_team_name(name, load_parser_config())
 
 def _discover_score_files(data_dir=DATA_DIR):
-    files = [os.path.join(data_dir, fn) for fn in os.listdir(data_dir) if fn.endswith(SCORES_GLOB_SUFFIX)]
-    return sorted(files)
+    return discover_score_files(data_dir)
 
 def _parse_game_line_anchored(line):
-    raw = line.strip()
-    if _is_skippable_line(raw):
-        return None
-    if re.search(r"\s+d\.\s+", raw, flags=re.IGNORECASE):
-        a, b = re.split(r"\s+d\.\s+", raw, maxsplit=1, flags=re.IGNORECASE)
-        return {
-            "team1": _normalize_team_name(a.strip()),
-            "score1": None,
-            "team2": _normalize_team_name(b.strip()),
-            "score2": None,
-        }
-    m = RESULT_PATTERN.match(raw)
-    if not m:
-        return None
-    team1 = _normalize_team_name(m.group("team1"))
-    team2 = _normalize_team_name(m.group("team2"))
-    return {
-        "team1": team1,
-        "score1": int(m.group("score1")),
-        "team2": team2,
-        "score2": int(m.group("score2")),
-    }
+    return parse_game_line_anchored(line, load_parser_config())
 
 def _build_file_fingerprint(files):
     payload = []

--- a/domain/parsing.py
+++ b/domain/parsing.py
@@ -1,15 +1,36 @@
+import json
 import os
 import re
+from pathlib import Path
 
 import pandas as pd
 
-from config.constants import DATA_DIR, RESULT_PATTERN, SCORES_GLOB_SUFFIX, TEAM_ALIASES, TRAILING_PLACEMENT_TAG
+from config.constants import DATA_DIR, SCORES_GLOB_SUFFIX
+
+_DEFAULT_SCORE_PATTERN = (
+    r"^\s*(?P<team1>.+?)\s+(?P<score1>\d+)\s+"
+    r"(?P<team2>.+?)\s+(?P<score2>\d+)\s*"
+    r"(?:(?:\((?:OT|SO)\))|(?:OT)|(?:SO)|(?:\([^)]*OT[^)]*\))|(?:\((?:\d+(?:st|nd|rd|th)\s+Place|Final)\)))?\s*$"
+)
+
+DEFAULT_PARSER_CONFIG = {
+    "aliases": {"chicago u": "U-Chicago", "chicago-u": "U-Chicago"},
+    "cleanup_suffix_patterns": [r"\s*\((?:\d+(?:st|nd|rd|th)\s+Place|Final)\)\s*$"],
+    "score_pattern": _DEFAULT_SCORE_PATTERN,
+}
 
 
-def normalize_team_name(name):
-    cleaned = TRAILING_PLACEMENT_TAG.sub("", name).strip()
-    canonical = TEAM_ALIASES.get(cleaned.lower())
-    return canonical if canonical else cleaned
+
+def load_parser_config(config_path="parser_config.json"):
+    cfg = dict(DEFAULT_PARSER_CONFIG)
+    if Path(config_path).exists():
+        with open(config_path, "r", encoding="utf-8") as fh:
+            user_cfg = json.load(fh) or {}
+        cfg.update({k: v for k, v in user_cfg.items() if v is not None})
+    cfg["aliases"] = {k.lower(): v for k, v in cfg.get("aliases", {}).items()}
+    cfg["cleanup_suffix_regexes"] = [re.compile(p, flags=re.IGNORECASE) for p in cfg.get("cleanup_suffix_patterns", [])]
+    cfg["score_regex"] = re.compile(cfg.get("score_pattern", _DEFAULT_SCORE_PATTERN), flags=re.IGNORECASE)
+    return cfg
 
 
 def is_skippable_line(raw):
@@ -29,28 +50,50 @@ def is_skippable_line(raw):
     return False
 
 
-def parse_game_line_anchored(line):
+def apply_rule_c_cleanup_suffix(name, parser_config):
+    out = name.strip()
+    for pattern in parser_config["cleanup_suffix_regexes"]:
+        out = pattern.sub("", out).strip()
+    return out
+
+
+def apply_rule_d_alias_normalization(name, parser_config):
+    canonical = parser_config["aliases"].get(name.lower())
+    return canonical if canonical else name
+
+
+def normalize_team_name(name, parser_config=None):
+    cfg = parser_config or load_parser_config()
+    cleaned = apply_rule_c_cleanup_suffix(name, cfg)
+    return apply_rule_d_alias_normalization(cleaned, cfg)
+
+
+def parse_game_line_anchored(line, parser_config=None):
+    cfg = parser_config or load_parser_config()
     raw = line.strip()
     if is_skippable_line(raw):
         return None
+    # Rule A: strict score pattern
+    m = cfg["score_regex"].match(raw)
+    if m:
+        return {
+            "team1": normalize_team_name(m.group("team1"), cfg),
+            "score1": int(m.group("score1")),
+            "team2": normalize_team_name(m.group("team2"), cfg),
+            "score2": int(m.group("score2")),
+        }
+    # Rule B: winner-only notation (d.)
     if re.search(r"\s+d\.\s+", raw, flags=re.IGNORECASE):
         a, b = re.split(r"\s+d\.\s+", raw, maxsplit=1, flags=re.IGNORECASE)
-        return {"team1": normalize_team_name(a.strip()), "score1": None, "team2": normalize_team_name(b.strip()), "score2": None}
-    m = RESULT_PATTERN.match(raw)
-    if not m:
-        return None
-    return {
-        "team1": normalize_team_name(m.group("team1")),
-        "score1": int(m.group("score1")),
-        "team2": normalize_team_name(m.group("team2")),
-        "score2": int(m.group("score2")),
-    }
+        return {"team1": normalize_team_name(a, cfg), "score1": None, "team2": normalize_team_name(b, cfg), "score2": None}
+    return None
 
 
-def parse_scores_text(text):
+def parse_scores_text(text, parser_config=None):
     records = []
+    cfg = parser_config or load_parser_config()
     for line in text.splitlines():
-        parsed = parse_game_line_anchored(line)
+        parsed = parse_game_line_anchored(line, cfg)
         if parsed is not None:
             records.append(parsed)
     return pd.DataFrame(records)

--- a/parser_config.json
+++ b/parser_config.json
@@ -1,0 +1,9 @@
+{
+  "aliases": {
+    "chicago u": "U-Chicago",
+    "chicago-u": "U-Chicago"
+  },
+  "cleanup_suffix_patterns": [
+    "\\s*\\((?:\\d+(?:st|nd|rd|th)\\s+Place|Final)\\)\\s*$"
+  ]
+}

--- a/tests/data/parser_line_fixtures.json
+++ b/tests/data/parser_line_fixtures.json
@@ -1,0 +1,15 @@
+{
+  "rule_a": [
+    {"line": "Loyola 8 Fenwick 5", "team1": "Loyola", "score1": 8, "team2": "Fenwick", "score2": 5},
+    {"line": "New Trier 7 Sandburg 6 (OT)", "team1": "New Trier", "score1": 7, "team2": "Sandburg", "score2": 6}
+  ],
+  "rule_b": [
+    {"line": "Stevenson d. Latin", "team1": "Stevenson", "team2": "Latin"}
+  ],
+  "rule_c": [
+    {"raw": "Brother Rice (3rd Place)", "normalized": "Brother Rice"}
+  ],
+  "rule_d": [
+    {"raw": "Chicago U", "normalized": "U-Chicago"}
+  ]
+}

--- a/tests/test_parsing_module.py
+++ b/tests/test_parsing_module.py
@@ -1,6 +1,45 @@
-from domain.parsing import normalize_team_name, parse_game_line_anchored
+import json
+from pathlib import Path
 
-def test_parse_and_normalize():
-    assert normalize_team_name('Chicago U') == 'U-Chicago'
-    row = parse_game_line_anchored('Loyola 8 Fenwick 5')
-    assert row['score1'] == 8
+from domain.parsing import (
+    apply_rule_c_cleanup_suffix,
+    apply_rule_d_alias_normalization,
+    load_parser_config,
+    parse_game_line_anchored,
+)
+
+FIXTURES = json.loads(Path("tests/data/parser_line_fixtures.json").read_text(encoding="utf-8"))
+
+
+def test_rule_a_strict_score_pattern():
+    cfg = load_parser_config()
+    for case in FIXTURES["rule_a"]:
+        row = parse_game_line_anchored(case["line"], cfg)
+        assert row is not None
+        assert row["team1"] == case["team1"]
+        assert row["score1"] == case["score1"]
+        assert row["team2"] == case["team2"]
+        assert row["score2"] == case["score2"]
+
+
+def test_rule_b_winner_only_notation():
+    cfg = load_parser_config()
+    for case in FIXTURES["rule_b"]:
+        row = parse_game_line_anchored(case["line"], cfg)
+        assert row is not None
+        assert row["team1"] == case["team1"]
+        assert row["team2"] == case["team2"]
+        assert row["score1"] is None
+        assert row["score2"] is None
+
+
+def test_rule_c_suffix_cleanup_only():
+    cfg = load_parser_config()
+    for case in FIXTURES["rule_c"]:
+        assert apply_rule_c_cleanup_suffix(case["raw"], cfg) == case["normalized"]
+
+
+def test_rule_d_alias_normalization_only():
+    cfg = load_parser_config()
+    for case in FIXTURES["rule_d"]:
+        assert apply_rule_d_alias_normalization(case["raw"], cfg) == case["normalized"]


### PR DESCRIPTION
### Motivation
- Consolidate and simplify score-line parsing by introducing an explicit multi-rule pipeline so rules are easier to reason about and extend. 
- Make common cleanup and aliasing behavior editable by non-developers via JSON rather than code edits. 
- Reduce duplication between the UI and domain parsing so the same logic is used everywhere.

### Description
- Implemented a configurable parser in `domain/parsing.py` with `load_parser_config()` and four explicit rules: Rule A (strict `score_regex`), Rule B (winner-only `d.` notation), Rule C (cleanup of trailing placement/final suffixes), and Rule D (alias normalization). 
- Added `parser_config.json` with default alias and cleanup patterns and supported loading user overrides at runtime. 
- Rewired `app/ui.py` to delegate parsing helpers (`_parse_game_line_anchored`, `_is_skippable_line`, `_normalize_team_name`, and `_discover_score_files`) to the shared domain parser to remove duplicated regex/constants. 
- Added representative line fixtures in `tests/data/parser_line_fixtures.json` and rewrote `tests/test_parsing_module.py` to validate each rule independently (also added `apply_rule_c_cleanup_suffix` and `apply_rule_d_alias_normalization` tests).

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_parsing_module.py test_parser_safety_net.py` and the test suite passed with `6 passed`.
- The parsing module tests validate each rule (A–D) against the fixture file `tests/data/parser_line_fixtures.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19818605c832ca40e6ce36a95d77f)