### PR TITLE
Add 3-Metric team profile scatter (Win%, AdjPyth, Elo) with interactive controls

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -243,6 +243,31 @@ def build_dashboard_view_model(stats, win_ord, games_inferred, weekly_ranks, win
             {"Category": "Inferred", "Count": inferred_results},
         ]),
     }
+
+def build_team_profile_3metric_df(stats, adj_vals, elo, sos, min_games):
+    rows = []
+    eligible = [t for t in stats.keys() if stats[t]["games"] >= min_games and t in adj_vals and t in elo]
+    win_ord_local = sorted(eligible, key=lambda t: stats[t]["win_pct"], reverse=True)
+    adj_ord_local = sorted(eligible, key=lambda t: adj_vals[t], reverse=True)
+    elo_ord_local = sorted(eligible, key=lambda t: elo[t], reverse=True)
+    win_rank = {t: i + 1 for i, t in enumerate(win_ord_local)}
+    adj_rank = {t: i + 1 for i, t in enumerate(adj_ord_local)}
+    elo_rank = {t: i + 1 for i, t in enumerate(elo_ord_local)}
+    for team in eligible:
+        rows.append(
+            {
+                "Team": team,
+                "WinPct": stats[team]["win_pct"],
+                "AdjPyth": adj_vals[team],
+                "Elo": elo[team],
+                "Games": stats[team]["games"],
+                "SOS": sos.get(team, 0.0),
+                "WinRank": win_rank.get(team),
+                "AdjRank": adj_rank.get(team),
+                "EloRank": elo_rank.get(team),
+            }
+        )
+    return pd.DataFrame(rows)
 def parse_scores_text(text):
     records = []
     for line in text.splitlines():
@@ -1554,8 +1579,8 @@ def main():
         return
 
     section_defaults = {"Team Profile": "Profile", "Rank Tables": "Win%", "Sectionals": "Sectionals"}
-    all_sections = ["Profile","Win%","Pythag","AdjPyth","Elo","Avg","Sectionals"]
-    available_sections = {"Team Profile": ["Profile"], "Rank Tables": ["Win%","Pythag","AdjPyth","Elo","Avg"], "Sectionals": ["Sectionals"]}.get(current_nav, all_sections)
+    all_sections = ["Profile","Win%","Pythag","AdjPyth","Elo","Avg","3-Metric Plot","Sectionals"]
+    available_sections = {"Team Profile": ["Profile"], "Rank Tables": ["Win%","Pythag","AdjPyth","Elo","Avg","3-Metric Plot"], "Sectionals": ["Sectionals"]}.get(current_nav, all_sections)
     default_section = section_defaults.get(current_nav, "Profile")
     if "content_section" not in st.session_state or st.session_state["content_section"] not in available_sections:
         st.session_state["content_section"] = default_section if default_section in available_sections else available_sections[0]
@@ -1867,6 +1892,92 @@ def main():
             )
             disagreement_chart = alt.hconcat(disagreement_indicator, model_heatmap, spacing=8).resolve_scale(y="shared")
             st.altair_chart(disagreement_chart.properties(height=360), use_container_width=True)
+
+    if selected_section == "3-Metric Plot":
+        st.subheader("Team Profile Space: Win% vs Adjusted Pythagorean vs Elo")
+        st.caption("Elo is encoded as a third-axis proxy using color or size.")
+        ctl1, ctl2, ctl3 = st.columns([1, 1, 1.5])
+        with ctl1:
+            elo_encoding_mode = st.radio("Elo encoding", ["Color", "Size"], horizontal=True, key="profile3d_elo_encoding")
+        with ctl2:
+            max_games = max(sts["games"] for sts in stats.values()) if stats else 1
+            min_games_plot = st.slider("Minimum games", min_value=0, max_value=max_games, value=int(round(thr)), step=1, key="profile3d_min_games")
+        with ctl3:
+            team_search = st.text_input("Team search highlight", value="", key="profile3d_search").strip().lower()
+
+        profile_df = build_team_profile_3metric_df(stats, adj_vals, elo, sos, min_games_plot)
+        if profile_df.empty:
+            st.info("No teams meet the current minimum games threshold.")
+        else:
+            focus_options = ["(None)"] + sorted(profile_df["Team"].tolist())
+            focus_team = st.selectbox("Focus team", options=focus_options, index=0, key="profile3d_focus_team")
+            profile_df["SearchHit"] = profile_df["Team"].str.lower().str.contains(team_search, regex=False) if team_search else False
+            profile_df["IsFocus"] = profile_df["Team"] == focus_team
+            profile_df["Highlight"] = profile_df["IsFocus"] | profile_df["SearchHit"]
+            elo_min = float(profile_df["Elo"].min())
+            elo_max = float(profile_df["Elo"].max())
+            elo_span = max(elo_max - elo_min, 1e-6)
+            profile_df["EloNorm"] = (profile_df["Elo"] - elo_min) / elo_span
+
+            hover_sel = alt.selection_point(fields=["Team"], on="mouseover", empty=True, name="team_hover")
+            base_opacity = alt.condition(hover_sel | alt.datum.Highlight, alt.value(1.0), alt.value(0.25))
+
+            color_encoding = alt.Color(
+                "EloNorm:Q",
+                scale=alt.Scale(domain=[0, 1], scheme="viridis"),
+                legend=alt.Legend(title=f"Elo ({elo_min:.0f}–{elo_max:.0f})"),
+            )
+            if elo_encoding_mode == "Color":
+                points = alt.Chart(profile_df).mark_circle(size=100).encode(
+                    x=alt.X("WinPct:Q", title="Win %"),
+                    y=alt.Y("AdjPyth:Q", title="Adjusted Pythagorean"),
+                    color=color_encoding,
+                    opacity=base_opacity,
+                    tooltip=[
+                        "Team:N",
+                        alt.Tooltip("WinPct:Q", format=".3f"),
+                        alt.Tooltip("AdjPyth:Q", format=".3f"),
+                        alt.Tooltip("Elo:Q", format=".1f"),
+                        "Games:Q",
+                        alt.Tooltip("SOS:Q", format=".3f"),
+                        "WinRank:Q",
+                        "AdjRank:Q",
+                        "EloRank:Q",
+                    ],
+                )
+            else:
+                points = alt.Chart(profile_df).mark_circle(color="#1D4ED8").encode(
+                    x=alt.X("WinPct:Q", title="Win %"),
+                    y=alt.Y("AdjPyth:Q", title="Adjusted Pythagorean"),
+                    size=alt.Size(
+                        "EloNorm:Q",
+                        legend=alt.Legend(title=f"Elo ({elo_min:.0f}–{elo_max:.0f})"),
+                        scale=alt.Scale(domain=[0, 1], range=[40, 900]),
+                    ),
+                    opacity=base_opacity,
+                    tooltip=[
+                        "Team:N",
+                        alt.Tooltip("WinPct:Q", format=".3f"),
+                        alt.Tooltip("AdjPyth:Q", format=".3f"),
+                        alt.Tooltip("Elo:Q", format=".1f"),
+                        "Games:Q",
+                        alt.Tooltip("SOS:Q", format=".3f"),
+                        "WinRank:Q",
+                        "AdjRank:Q",
+                        "EloRank:Q",
+                    ],
+                )
+
+            labels = alt.Chart(profile_df[profile_df["IsFocus"]]).mark_text(
+                align="left", baseline="bottom", dx=6, dy=-4, color=SEMANTIC_COLORS["neutral"]
+            ).encode(
+                x="WinPct:Q",
+                y="AdjPyth:Q",
+                text="Team:N",
+            )
+
+            chart = (points.add_params(hover_sel) + labels).properties(height=460)
+            st.altair_chart(chart, use_container_width=True)
         st.markdown("### Expert Fit")
         illpolo_order = parse_expert_order_text(illpolo_text)
         maxpreps_order = parse_expert_order_text(maxpreps_text)


### PR DESCRIPTION
### Motivation
- Provide an interactive 2D team-profile visualization that surfaces Win%, adjusted Pythagorean, and Elo as a third encoded metric to help compare teams across multiple dimensions.
- Allow filtering by minimum games, highlight/search teams, and toggle Elo encoding to improve exploratory analysis and trust in rankings.

### Description
- Added `build_team_profile_3metric_df(stats, adj_vals, elo, sos, min_games)` to assemble a DataFrame containing WinPct, AdjPyth, Elo, SOS, Games and rank columns for teams that meet the minimum games threshold.
- Extended navigation to include a new "3-Metric Plot" section and added the corresponding UI block which provides controls for Elo encoding mode (Color/Size), minimum games slider, and team search/focus.
- Implemented an Altair scatter chart that plots `WinPct` vs `AdjPyth`, encodes Elo either as color or size, supports hover highlighting, focus label rendering, and computes normalized Elo for visual scaling.
- Handles empty datasets and highlights/search hits, and preserves existing tooltips and layout conventions.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3783e9044832c99b620cf061646c9)