### PR TITLE
Set SOS color gradient to red→yellow→green and polish 3‑metric profile charts

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -243,6 +243,31 @@ def build_dashboard_view_model(stats, win_ord, games_inferred, weekly_ranks, win
             {"Category": "Inferred", "Count": inferred_results},
         ]),
     }
+
+def build_team_profile_3metric_df(stats, adj_vals, elo, sos, min_games):
+    rows = []
+    eligible = [t for t in stats.keys() if stats[t]["games"] >= min_games and t in adj_vals and t in elo]
+    win_ord_local = sorted(eligible, key=lambda t: stats[t]["win_pct"], reverse=True)
+    adj_ord_local = sorted(eligible, key=lambda t: adj_vals[t], reverse=True)
+    elo_ord_local = sorted(eligible, key=lambda t: elo[t], reverse=True)
+    win_rank = {t: i + 1 for i, t in enumerate(win_ord_local)}
+    adj_rank = {t: i + 1 for i, t in enumerate(adj_ord_local)}
+    elo_rank = {t: i + 1 for i, t in enumerate(elo_ord_local)}
+    for team in eligible:
+        rows.append(
+            {
+                "Team": team,
+                "WinPct": stats[team]["win_pct"],
+                "AdjPyth": adj_vals[team],
+                "Elo": elo[team],
+                "Games": stats[team]["games"],
+                "SOS": sos.get(team, 0.0),
+                "WinRank": win_rank.get(team),
+                "AdjRank": adj_rank.get(team),
+                "EloRank": elo_rank.get(team),
+            }
+        )
+    return pd.DataFrame(rows)
 def parse_scores_text(text):
     records = []
     for line in text.splitlines():
@@ -1554,8 +1579,8 @@ def main():
         return
 
     section_defaults = {"Team Profile": "Profile", "Rank Tables": "Win%", "Sectionals": "Sectionals"}
-    all_sections = ["Profile","Win%","Pythag","AdjPyth","Elo","Avg","Sectionals"]
-    available_sections = {"Team Profile": ["Profile"], "Rank Tables": ["Win%","Pythag","AdjPyth","Elo","Avg"], "Sectionals": ["Sectionals"]}.get(current_nav, all_sections)
+    all_sections = ["Profile","Win%","Pythag","AdjPyth","Elo","Avg","3-Metric Plot","Sectionals"]
+    available_sections = {"Team Profile": ["Profile"], "Rank Tables": ["Win%","Pythag","AdjPyth","Elo","Avg","3-Metric Plot"], "Sectionals": ["Sectionals"]}.get(current_nav, all_sections)
     default_section = section_defaults.get(current_nav, "Profile")
     if "content_section" not in st.session_state or st.session_state["content_section"] not in available_sections:
         st.session_state["content_section"] = default_section if default_section in available_sections else available_sections[0]
@@ -1867,6 +1892,111 @@ def main():
             )
             disagreement_chart = alt.hconcat(disagreement_indicator, model_heatmap, spacing=8).resolve_scale(y="shared")
             st.altair_chart(disagreement_chart.properties(height=360), use_container_width=True)
+
+    if selected_section == "3-Metric Plot":
+        st.subheader("Team Profile Space: Win% vs Adjusted Pythagorean (Elo size, SOS color)")
+        st.caption("Elo is encoded by size (third-axis proxy) and Strength of Schedule (SOS) is encoded by color (red = weaker, yellow = mid, green = harder).")
+        ctl1, ctl2 = st.columns([1, 1.5])
+        with ctl1:
+            st.caption("Encoding: Elo → size · SOS → color (red → yellow → green)")
+        with ctl2:
+            max_games = max(sts["games"] for sts in stats.values()) if stats else 1
+            min_games_plot = st.slider("Minimum games", min_value=0, max_value=max_games, value=int(round(thr)), step=1, key="profile3d_min_games")
+        team_search = st.text_input("Team search highlight", value="", key="profile3d_search").strip().lower()
+
+        profile_df = build_team_profile_3metric_df(stats, adj_vals, elo, sos, min_games_plot)
+        if profile_df.empty:
+            st.info("No teams meet the current minimum games threshold.")
+        else:
+            focus_options = ["(None)"] + sorted(profile_df["Team"].tolist())
+            focus_team = st.selectbox("Focus team", options=focus_options, index=0, key="profile3d_focus_team")
+            profile_df["SearchHit"] = profile_df["Team"].str.lower().str.contains(team_search, regex=False) if team_search else False
+            profile_df["IsFocus"] = profile_df["Team"] == focus_team
+            profile_df["Highlight"] = profile_df["IsFocus"] | profile_df["SearchHit"]
+            elo_min = float(profile_df["Elo"].min())
+            elo_max = float(profile_df["Elo"].max())
+            elo_span = max(elo_max - elo_min, 1e-6)
+            profile_df["EloNorm"] = (profile_df["Elo"] - elo_min) / elo_span
+            sos_min = float(profile_df["SOS"].min())
+            sos_max = float(profile_df["SOS"].max())
+
+            hover_sel = alt.selection_point(fields=["Team"], on="mouseover", empty=True, name="team_hover")
+            base_opacity = alt.condition(hover_sel | alt.datum.Highlight, alt.value(1.0), alt.value(0.25))
+
+            sos_color = alt.Color(
+                "SOS:Q",
+                scale=alt.Scale(
+                    domain=[sos_min, (sos_min + sos_max) / 2.0, sos_max],
+                    range=["#B91C1C", "#FACC15", "#15803D"],
+                ),
+                legend=alt.Legend(title=f"SOS ({sos_min:.3f}–{sos_max:.3f})"),
+            )
+            points = alt.Chart(profile_df).mark_circle().encode(
+                x=alt.X("WinPct:Q", title="Win %"),
+                y=alt.Y("AdjPyth:Q", title="Adjusted Pythagorean"),
+                size=alt.Size(
+                    "EloNorm:Q",
+                    legend=alt.Legend(title=f"Elo ({elo_min:.0f}–{elo_max:.0f})"),
+                    scale=alt.Scale(domain=[0, 1], range=[40, 900]),
+                ),
+                color=sos_color,
+                opacity=base_opacity,
+                tooltip=[
+                    "Team:N",
+                    alt.Tooltip("WinPct:Q", format=".3f"),
+                    alt.Tooltip("AdjPyth:Q", format=".3f"),
+                    alt.Tooltip("Elo:Q", format=".1f"),
+                    "Games:Q",
+                    alt.Tooltip("SOS:Q", format=".3f"),
+                    "WinRank:Q",
+                    "AdjRank:Q",
+                    "EloRank:Q",
+                ],
+            )
+
+            labels = alt.Chart(profile_df[profile_df["IsFocus"]]).mark_text(
+                align="left", baseline="bottom", dx=6, dy=-4, color=SEMANTIC_COLORS["neutral"]
+            ).encode(
+                x="WinPct:Q",
+                y="AdjPyth:Q",
+                text="Team:N",
+            )
+
+            chart = (points.add_params(hover_sel) + labels).properties(height=460)
+            st.altair_chart(chart, use_container_width=True)
+
+            gpg_df = profile_df.copy()
+            gpg_df["GoalsFor"] = gpg_df["Team"].map(lambda t: stats[t]["gf"] / max(stats[t]["games"], 1))
+            gpg_df["GoalsAgainst"] = gpg_df["Team"].map(lambda t: stats[t]["ga"] / max(stats[t]["games"], 1))
+            st.subheader("Team Profile Space: Goals For vs Goals Against (inverted Y)")
+            st.caption("Elo is encoded by size and SOS by color; lower Goals Against appears higher due inverted y-axis.")
+            gpg_points = alt.Chart(gpg_df).mark_circle().encode(
+                x=alt.X("GoalsFor:Q", title="Goals For / Game"),
+                y=alt.Y("GoalsAgainst:Q", title="Goals Against / Game", scale=alt.Scale(reverse=True)),
+                size=alt.Size(
+                    "EloNorm:Q",
+                    legend=alt.Legend(title=f"Elo ({elo_min:.0f}–{elo_max:.0f})"),
+                    scale=alt.Scale(domain=[0, 1], range=[40, 900]),
+                ),
+                color=sos_color,
+                opacity=base_opacity,
+                tooltip=[
+                    "Team:N",
+                    alt.Tooltip("GoalsFor:Q", format=".2f"),
+                    alt.Tooltip("GoalsAgainst:Q", format=".2f"),
+                    alt.Tooltip("Elo:Q", format=".1f"),
+                    alt.Tooltip("SOS:Q", format=".3f"),
+                    "Games:Q",
+                ],
+            )
+            gpg_labels = alt.Chart(gpg_df[gpg_df["IsFocus"]]).mark_text(
+                align="left", baseline="bottom", dx=6, dy=-4, color=SEMANTIC_COLORS["neutral"]
+            ).encode(
+                x="GoalsFor:Q",
+                y="GoalsAgainst:Q",
+                text="Team:N",
+            )
+            st.altair_chart((gpg_points.add_params(hover_sel) + gpg_labels).properties(height=460), use_container_width=True)
         st.markdown("### Expert Fit")
         illpolo_order = parse_expert_order_text(illpolo_text)
         maxpreps_order = parse_expert_order_text(maxpreps_text)


### PR DESCRIPTION
### Motivation
- Provide a clearer visual semantics for Strength of Schedule so low SOS reads as red (weaker) and high SOS reads as green (harder). 
- Surface a compact multi‑metric view (Win% / AdjPyth / Elo / SOS) and a Goals For / Goals Against view to help compare teams across three axes. 
- Improve perceptual separation for Elo and SOS encodings so points are visually distinguishable across the current filtered view.

### Description
- Added a helper `build_team_profile_3metric_df(stats, adj_vals, elo, sos, min_games)` to construct the eligible-team DataFrame used by the profile charts. 
- Introduced a `3-Metric Plot` UI section with two Altair charts: `WinPct` vs `AdjPyth` (Elo → size, SOS → color) and `GoalsFor` vs inverted `GoalsAgainst` (Elo → size, SOS → color), preserving hover/tooltips, focus selection, search highlight, and point dimming. 
- Normalized Elo per-view into `EloNorm` and expanded the size scale for better visual spread; updated color mapping for SOS to an explicit 3-stop domain with `range` set to `[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3783e9044832c99b620cf061646c9)