### PR TITLE
Remove custom 4-metric dashboard chart and controls from metrics view

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -415,26 +415,7 @@ def render_dashboard_metric_charts(stats, adj_vals, elo, sos, min_games_default=
             )
             st.altair_chart((chart3.add_params(hover_sel)).properties(height=420), use_container_width=True)
 
-    st.subheader("Custom 4-metric chart")
-    metric_options = {
-        "Win %": "WinPct", "Adjusted Pyth": "AdjPyth", "Elo": "Elo", "SOS": "SOS",
-        "Goals For / Game": "GoalsFor", "Goals Against / Game": "GoalsAgainst", "Games": "Games"
-    }
-    cx, cy, cs = st.columns(3)
-    x_metric = cx.selectbox("X-axis", list(metric_options.keys()), index=0, key="dashboard_custom_x")
-    y_metric = cy.selectbox("Y-axis", list(metric_options.keys()), index=1, key="dashboard_custom_y")
-    size_metric = cs.selectbox("Size", list(metric_options.keys()), index=2, key="dashboard_custom_size")
-    custom_df = gpg_df.copy()
-    c_top_n = st.slider("Custom chart: teams shown", min_value=5, max_value=len(custom_df), value=min(20, len(custom_df)), key="dashboard_custom_top_n")
-    c_metric = st.selectbox("Custom chart: ranking metric", ["Win %", "Adjusted Pyth", "Elo", "SOS"], key="dashboard_custom_rank_metric")
-    c_time = st.selectbox("Custom chart: time frame", ["Current season"], key="dashboard_custom_time")
-    rank_key = metric_options[c_metric]
-    custom_df = custom_df.sort_values(rank_key, ascending=False).head(c_top_n)
-    chart4 = alt.Chart(custom_df).mark_circle().encode(
-        x=alt.X(f"{metric_options[x_metric]}:Q", title=x_metric), y=alt.Y(f"{metric_options[y_metric]}:Q", title=y_metric),
-        size=alt.Size(f"{metric_options[size_metric]}:Q"), color=sos_color, opacity=base_opacity, tooltip=["Team:N"]
-    )
-    st.altair_chart((chart4.add_params(hover_sel)).properties(height=420), use_container_width=True)
+
 
 
 def build_rank_overview_chart(top_n_df, metric_label, metric_format):


### PR DESCRIPTION
### Motivation
- The custom 4-metric interactive chart and its auxiliary controls were redundant and added UI complexity to `render_dashboard_metric_charts(...)`.
- Removing the custom controls simplifies the metric-space charts code path and reduces surface area for stale state keys.

### Description
- Deleted the entire `Custom 4-metric chart` section from `app/ui.py`, including the `metric_options` dictionary, the X/Y/Size selectboxes, the custom top-N slider, ranking metric and time-frame selectboxes, and the chart construction for the custom chart.
- Removed the custom sorting/top-N logic that derived `rank_key` and filtered `custom_df` prior to charting.
- Confirmed the BCAR scatter (`chart3`) and the other metric charts remain intact and unaffected by the removal.

### Testing
- Ran a symbol search with `rg` to confirm occurrences of `metric_options`, `cx`, `cy`, `cs`, `c_top_n`, `c_metric`, `c_time`, `rank_key`, and `dashboard_custom_*` are no longer present in `app/ui.py`, and that only the expected `chart3` usage remains, which succeeded.
- Inspected the file region with `nl`/`sed` to verify the custom block was removed and surrounding chart code is intact, which succeeded.
- Performed an automated in-place edit to remove the block and validated that the file parses and the targeted UI controls/variables are no longer defined, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f387e5a938832c9a4f456e2074e6a8)