### PR TITLE
app: simplify primary navigation header controls

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -1720,15 +1720,22 @@ def main():
     is_deep_dive = False
 
     nav_options = ["Dashboard", "Team Profile", "Rank Tables", "Sectionals"]
+    nav_labels = {
+        "Dashboard": "Overview",
+        "Team Profile": "Teams",
+        "Rank Tables": "Rankings",
+        "Sectionals": "Sectionals",
+    }
     if "primary_nav" not in st.session_state or st.session_state["primary_nav"] not in nav_options:
         st.session_state["primary_nav"] = "Dashboard"
-    st.markdown("### Primary Navigation")
-    st.radio(
-        "Go to",
-        options=nav_options,
-        horizontal=True,
-        key="primary_nav",
-    )
+
+    nav_cols = st.columns(len(nav_options), gap="small")
+    for col, nav_key in zip(nav_cols, nav_options):
+        is_active = st.session_state["primary_nav"] == nav_key
+        button_kind = "primary" if is_active else "secondary"
+        if col.button(nav_labels[nav_key], key=f"primary_nav_btn_{nav_key}", use_container_width=True, type=button_kind):
+            st.session_state["primary_nav"] = nav_key
+
     current_nav = st.session_state["primary_nav"]
     config = load_model_config()
     ensemble_weights_cfg = sanitize_ensemble_weights(config.get("ensemble_weights", {}))


### PR DESCRIPTION
### Motivation
- Remove the literal `"Primary Navigation"` heading and the mixed heading + control pattern to make the top-of-page navigation read as a minimal control strip.
- Replace the radio control with a compact row of labeled buttons to improve visual hierarchy and make the options feel like controls rather than content.

### Description
- Replaced the `st.markdown("### Primary Navigation")` + `st.radio(...)` pattern in `main()` with a `nav_labels` mapping and a horizontal set of Streamlit columns containing labeled buttons in `app/ui.py`.
- Buttons map human-facing labels (`Overview`, `Teams`, `Rankings`, `Sectionals`) to the existing canonical route keys (`Dashboard`, `Team Profile`, `Rank Tables`, `Sectionals`) and update `st.session_state["primary_nav"]` to preserve routing behavior.
- Active state is preserved visually by setting button `type` to `primary` when active and `secondary` when inactive.

### Testing
- Ran `python -m py_compile app/ui.py` and compilation passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3fa8ea85c832c8691bf4eaf09a74e)