### PR TITLE
app: remove dashboard header text and global controls heading

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -515,7 +515,6 @@ def render_dashboard_header_kpis(kpi, metric_lens, metric_format):
 
 
 def render_dashboard_controls(preset_defaults):
-    st.markdown("### Global dashboard controls")
     st.radio("Persona preset", options=["Custom", "Fan", "Coach", "Analyst"], horizontal=True, key="dashboard_persona")
     selected_persona = st.session_state["dashboard_persona"]
     if selected_persona in preset_defaults and preset_defaults[selected_persona]:
@@ -2068,9 +2067,6 @@ def main():
 
     # Tabs & content
     if current_nav == "Dashboard":
-        render_typography("title", "Dashboard")
-        render_typography("subtitle", "League pulse with interactive metric charts and rank trends")
-
         if "dashboard_top_n" not in st.session_state:
             st.session_state["dashboard_top_n"] = 10
         if "dashboard_time_window" not in st.session_state:


### PR DESCRIPTION
### Motivation
- Declutter the dashboard top section by removing purely descriptive headings so functional controls and content are prominent and above-the-fold.

### Description
- Removed the top-level title rendering call `render_typography("title", "Dashboard")` from the dashboard view in `app/ui.py`.
- Removed the descriptive subtitle `render_typography("subtitle", "League pulse with interactive metric charts and rank trends")` from the dashboard view in `app/ui.py`.
- Removed the `st.markdown("### Global dashboard controls")` heading inside `render_dashboard_controls` so only actionable controls remain at the top section.
- Left control widgets and content modules unchanged so behavior and control flow are preserved and vertical gap is reduced implicitly by removing the rendered text blocks.

### Testing
- Ran `python -m py_compile app/ui.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3fb1c621c832c813f95007c52a553)