### PR TITLE
app: replace team count selector with Top 10 toggle

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -516,7 +516,7 @@ def render_dashboard_header_kpis(kpi, metric_lens, metric_format):
 
 def render_dashboard_controls():
     ctl_a, ctl_b, ctl_c = st.columns(3)
-    ctl_a.selectbox("Top N", options=[10, 15, 25], key="dashboard_top_n")
+    ctl_a.checkbox("Top 10 only", key="dashboard_top10_only")
     ctl_b.selectbox("Time window", options=["Last 4 weeks", "All"], key="dashboard_time_window")
     ctl_c.selectbox("Metric lens", options=["Win%", "Adj Pyth", "Elo", "Ensemble"], key="dashboard_metric_lens")
     with st.expander("Advanced options", expanded=False):
@@ -2060,8 +2060,8 @@ def main():
 
     # Tabs & content
     if current_nav == "Dashboard":
-        if "dashboard_top_n" not in st.session_state:
-            st.session_state["dashboard_top_n"] = 10
+        if "dashboard_top10_only" not in st.session_state:
+            st.session_state["dashboard_top10_only"] = False
         if "dashboard_time_window" not in st.session_state:
             st.session_state["dashboard_time_window"] = "Last 4 weeks"
         if "dashboard_metric_lens" not in st.session_state:
@@ -2070,8 +2070,8 @@ def main():
         st.session_state.pop("dashboard_persona", None)
 
         # Safe fallback for persisted/linked state values outside the current control options.
-        if st.session_state["dashboard_top_n"] not in [10, 15, 25]:
-            st.session_state["dashboard_top_n"] = 10
+        if not isinstance(st.session_state["dashboard_top10_only"], bool):
+            st.session_state["dashboard_top10_only"] = False
         if st.session_state["dashboard_time_window"] not in ["Last 4 weeks", "All"]:
             st.session_state["dashboard_time_window"] = "Last 4 weeks"
         if st.session_state["dashboard_metric_lens"] not in ["Win%", "Adj Pyth", "Elo", "Ensemble"]:
@@ -2112,7 +2112,7 @@ def main():
             games_inferred,
             weekly_ranks,
             window_size=window_size,
-            top_n_rank=st.session_state["dashboard_top_n"],
+            top_n_rank=10 if st.session_state["dashboard_top10_only"] else 25,
             trend_top_n=trend_top_n,
             movement_top_n=movement_top_n,
             primary_table=primary_payload["table"],


### PR DESCRIPTION
### Motivation
- Simplify dashboard team-count control to a single, unambiguous toggle so initial load defaults to Top 25 and the only other option is Top 10.
- Reduce UI complexity and ensure the team-count state is represented by a single boolean key in session state.

### Description
- Replaced multi-option `Top N` selectbox with a single checkbox `Top 10 only` in `render_dashboard_controls()` (UI column A). 
- Introduced and normalized a single session-state key `dashboard_top10_only` with default `False` and a type-safe fallback. 
- Derived `top_n_rank` exclusively from the toggle (`10` when `dashboard_top10_only` is `True`, otherwise `25`) when calling `build_dashboard_view_model()`.
- Removed reliance on the legacy `dashboard_top_n` values in the Dashboard code path so this toggle is the sole team-count control. 

### Testing
- Ran `pytest tests/test_parsing_module.py tests/test_ranking_module.py tests/test_hybrid_ranking_module.py tests/test_stats_module.py` which initially failed due to environment import path (`ModuleNotFoundError`).
- Ran `PYTHONPATH=. pytest tests/test_parsing_module.py tests/test_ranking_module.py tests/test_hybrid_ranking_module.py tests/test_stats_module.py` which passed all tests (`16 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3fc3e6778832cb34dfc84a3c7a5ba)