### PR TITLE
domain: add matchup prediction passthrough on hybrid ranker

### DIFF
--- a/domain/hybrid_ranking.py
+++ b/domain/hybrid_ranking.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, Literal, Optional
 
 import numpy as np
 import pandas as pd
@@ -28,6 +28,7 @@ class ScheduleAdjustedGoalStrengthRanker:
     def __init__(self, config: Optional[HybridRankingConfig] = None) -> None:
         self.config = config or HybridRankingConfig()
         self._is_fit = False
+        self._matchup_model = None
         self.fit_warnings_: list[str] = []
 
     def fit(self, games_df: pd.DataFrame, game_weights: Optional[Iterable[float]] = None) -> "ScheduleAdjustedGoalStrengthRanker":
@@ -133,8 +134,50 @@ class ScheduleAdjustedGoalStrengthRanker:
         if np.any(self.games_played_ < 2):
             self.fit_warnings_.append("very small sample size for one or more teams")
 
+        # lazy import to avoid circular import at module load time
+        from domain.matchup_model import PoissonAttackDefenseMatchupModel
+
+        self._matchup_model = PoissonAttackDefenseMatchupModel(ranking_model=self).fit(games)
         self._is_fit = True
         return self
+
+    def predict_matchup(
+        self,
+        team_a: str,
+        team_b: str,
+        venue: Literal["home", "away", "neutral"] = "neutral",
+        max_goals: int = 10,
+    ) -> dict[str, object]:
+        if not self._is_fit or self._matchup_model is None:
+            raise RuntimeError("Model must be fit before calling predict_matchup().")
+        if venue not in {"home", "away", "neutral"}:
+            raise ValueError("venue must be one of: home, away, neutral")
+
+        prediction = self._matchup_model.predict_matchup(
+            team_a=team_a,
+            team_b=team_b,
+            venue=venue,
+            max_goals=max_goals,
+        )
+
+        ordered_scorelines = sorted(
+            prediction["top_scorelines"],
+            key=lambda x: (-x["probability"], x["score_a"], x["score_b"]),
+        )
+
+        return {
+            "expected_goals_a": prediction["expected_goals_a"],
+            "expected_goals_b": prediction["expected_goals_b"],
+            "p_win": prediction["p_win"],
+            "p_draw": prediction["p_draw"],
+            "p_loss": prediction["p_loss"],
+            "top_scorelines": ordered_scorelines,
+            "goal_diff_interval_50": prediction["goal_diff_interval_50"],
+            "goal_diff_interval_80": prediction["goal_diff_interval_80"],
+            "total_goals_interval_50": prediction["total_goals_interval_50"],
+            "total_goals_interval_80": prediction["total_goals_interval_80"],
+            "matchup_confidence": prediction["matchup_confidence"],
+        }
 
     def rankings(self) -> pd.DataFrame:
         return self.rankings_table()

--- a/tests/test_hybrid_ranking_module.py
+++ b/tests/test_hybrid_ranking_module.py
@@ -90,3 +90,52 @@ def test_low_sample_teams_have_larger_se_than_high_information_teams():
 
     assert table.loc["Alpha", "games"] < table.loc["Echo", "games"]
     assert table.loc["Alpha", "rating_se"] > table.loc["Echo", "rating_se"]
+
+
+def test_predict_matchup_requires_fit():
+    model = ScheduleAdjustedGoalStrengthRanker()
+    try:
+        model.predict_matchup("Alpha", "Bravo")
+        raise AssertionError("Expected RuntimeError when calling predict_matchup before fit")
+    except RuntimeError as exc:
+        assert "fit before calling predict_matchup" in str(exc)
+
+
+def test_predict_matchup_validates_venue():
+    games = _load_hybrid_games()
+    model = ScheduleAdjustedGoalStrengthRanker().fit(games)
+
+    try:
+        model.predict_matchup("Alpha", "Bravo", venue="mars")  # type: ignore[arg-type]
+        raise AssertionError("Expected ValueError for invalid venue")
+    except ValueError as exc:
+        assert "venue must be one of" in str(exc)
+
+
+def test_predict_matchup_schema_and_deterministic_scoreline_ordering():
+    games = _load_hybrid_games()
+    model = ScheduleAdjustedGoalStrengthRanker().fit(games)
+    pred = model.predict_matchup("Alpha", "Bravo", venue="neutral", max_goals=8)
+
+    assert set(pred.keys()) == {
+        "expected_goals_a",
+        "expected_goals_b",
+        "p_win",
+        "p_draw",
+        "p_loss",
+        "top_scorelines",
+        "goal_diff_interval_50",
+        "goal_diff_interval_80",
+        "total_goals_interval_50",
+        "total_goals_interval_80",
+        "matchup_confidence",
+    }
+
+    scorelines = pred["top_scorelines"]
+    assert isinstance(scorelines, list)
+    for idx in range(1, len(scorelines)):
+        prev = scorelines[idx - 1]
+        curr = scorelines[idx]
+        prev_key = (-prev["probability"], prev["score_a"], prev["score_b"])
+        curr_key = (-curr["probability"], curr["score_a"], curr["score_b"])
+        assert prev_key <= curr_key


### PR DESCRIPTION
### Motivation
- Expose matchup forecasting from the hybrid ranking API so callers can get Poisson-based predictions without instantiating a separate matchup model.
- Propagate ranking-derived confidence into matchup forecasts so predictions reflect ranking uncertainty.
- Provide deterministic and tightly specified prediction output to make downstream consumers robust to ordering and schema changes.

### Description
- Added a private `_matchup_model` attribute to `ScheduleAdjustedGoalStrengthRanker` and instantiate+fit a `PoissonAttackDefenseMatchupModel` inside `fit(...)` using the same `games_df` and `ranking_model=self` for confidence propagation.
- Introduced a public `predict_matchup(team_a, team_b, venue="neutral", max_goals=10)` method that delegates to the fitted Poisson model and returns only the required schema keys (`expected_goals_a`, `expected_goals_b`, `p_win`, `p_draw`, `p_loss`, `top_scorelines`, `goal_diff_interval_50`, `goal_diff_interval_80`, `total_goals_interval_50`, `total_goals_interval_80`, `matchup_confidence`).
- Added guardrails: `predict_matchup` raises a clear `RuntimeError` if called before `fit`, validates `venue` values, and enforces deterministic ordering of `top_scorelines` by sorting on probability (desc) then `score_a`, `score_b` for tie-breaking.
- Added unit tests in `tests/test_hybrid_ranking_module.py` to assert pre-fit failure, venue validation, exact output key set, and deterministic `top_scorelines` ordering.

### Testing
- Ran `pytest tests/test_parsing_module.py tests/test_ranking_module.py tests/test_hybrid_ranking_module.py tests/test_stats_module.py` which initially failed in this environment due to an import path issue (`ModuleNotFoundError: No module named 'domain'`).
- Re-ran with `PYTHONPATH=. pytest tests/test_parsing_module.py tests/test_ranking_module.py tests/test_hybrid_ranking_module.py tests/test_stats_module.py` and all tests passed (`19 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51b25a8f8832ca37679d38523cc16)