### PR TITLE
domain: export hybrid ranking symbols from ranking module

### DIFF
--- a/domain/ranking.py
+++ b/domain/ranking.py
@@ -1,4 +1,5 @@
 from app.ui import compute_adjusted_pythag, compute_elo, compute_pythag, rank_adj_pyth, rank_elo, rank_pythag
+from domain.hybrid_ranking import HybridRankingConfig, ScheduleAdjustedGoalStrengthRanker
 
 __all__ = [
     "compute_elo",
@@ -7,4 +8,6 @@ __all__ = [
     "rank_pythag",
     "rank_adj_pyth",
     "rank_elo",
+    "ScheduleAdjustedGoalStrengthRanker",
+    "HybridRankingConfig",
 ]

--- a/tests/test_ranking_module.py
+++ b/tests/test_ranking_module.py
@@ -110,3 +110,12 @@ def test_backward_compatible_weights_when_bcar_missing_from_config():
     assert "BCAR" in weights
     assert weights["BCAR"] > 0
     assert abs(sum(weights.values()) - 1.0) < 1e-9
+
+
+def test_hybrid_symbols_importable_from_domain_ranking():
+    from domain.hybrid_ranking import HybridRankingConfig, ScheduleAdjustedGoalStrengthRanker
+    from domain.ranking import HybridRankingConfig as ExportedHybridRankingConfig
+    from domain.ranking import ScheduleAdjustedGoalStrengthRanker as ExportedScheduleAdjustedGoalStrengthRanker
+
+    assert ExportedHybridRankingConfig is HybridRankingConfig
+    assert ExportedScheduleAdjustedGoalStrengthRanker is ScheduleAdjustedGoalStrengthRanker


### PR DESCRIPTION
### Motivation
- Allow consumers to import `ScheduleAdjustedGoalStrengthRanker` and `HybridRankingConfig` from `domain.ranking` to preserve backward compatibility and simplify import paths.
- Keep existing public API stable while adding the hybrid-ranking types to the module exports.

### Description
- Import `HybridRankingConfig` and `ScheduleAdjustedGoalStrengthRanker` from `domain.hybrid_ranking` in `domain/ranking.py` and append both names to `__all__` without removing or changing existing exports.
- Add a focused unit test `test_hybrid_symbols_importable_from_domain_ranking` in `tests/test_ranking_module.py` that asserts the exported symbols from `domain.ranking` are the same objects as those defined in `domain.hybrid_ranking`.

### Testing
- Ran `pytest tests/test_ranking_module.py` and it passed.
- Ran `pytest tests/test_hybrid_ranking_module.py` and it passed.
- Ran `PYTHONPATH=. pytest tests/test_parsing_module.py tests/test_stats_module.py` and both tests passed; note that running those parsing/stats tests in this environment without `PYTHONPATH=.` caused a `ModuleNotFoundError` during collection, so the `PYTHONPATH=.` invocation was used for validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51c0955d0832c84bcf215dd163474)