### PR TITLE
config: add backward-compatible config key mapper

### DIFF
--- a/config/model_params.py
+++ b/config/model_params.py
@@ -1,3 +1,11 @@
+from __future__ import annotations
+
+from dataclasses import fields
+from typing import Any, Mapping
+
+from domain.hybrid_ranking import HybridRankingConfig
+from domain.matchup_model import MatchupModelConfig
+
 DEFAULT_PYTHAG_EXP = 2
 DEFAULT_LOGISTIC_K = 10
 DEFAULT_LOGISTIC_X0 = 0.5
@@ -15,3 +23,62 @@ HYBRID_DEFAULTS = {
     "home_advantage": 0.1,
     "poisson_regularization": 0.2,
 }
+
+_HYBRID_ALIASES = {
+    "epsilon": "eps",
+    "margin_scale_s": "margin_scale",
+}
+_MATCHUP_ALIASES = {
+    "poisson_regularization": "ridge_lambda",
+}
+
+
+def _coerce_numeric(value: Any, key: str) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Config field '{key}' must be numeric; got {value!r}.") from exc
+    if not (numeric == numeric and numeric not in (float('inf'), float('-inf'))):
+        raise ValueError(f"Config field '{key}' must be a finite number; got {value!r}.")
+    return numeric
+
+
+def resolve_hybrid_and_matchup_configs(params: Mapping[str, Any] | None) -> tuple[HybridRankingConfig, MatchupModelConfig]:
+    """Map persisted config keys (including legacy aliases) into model configs."""
+    source = dict(HYBRID_DEFAULTS)
+    if params:
+        source.update(dict(params))
+
+    hybrid_keys = {field.name for field in fields(HybridRankingConfig)}
+    matchup_keys = {field.name for field in fields(MatchupModelConfig)}
+    allowed = set(HYBRID_DEFAULTS)
+    allowed.update(hybrid_keys)
+    allowed.update(matchup_keys)
+    allowed.update(_HYBRID_ALIASES)
+    allowed.update(_MATCHUP_ALIASES)
+    unknown = sorted(set(params or {}).difference(allowed))
+    if unknown:
+        raise ValueError(
+            "Unknown config field(s): " + ", ".join(unknown) + ". "
+            "Supported fields include hybrid keys plus aliases: "
+            "epsilon->eps, margin_scale_s->margin_scale, poisson_regularization->ridge_lambda."
+        )
+
+    hybrid_values: dict[str, Any] = {}
+    for key, value in source.items():
+        target = _HYBRID_ALIASES.get(key, key)
+        if target in hybrid_keys:
+            hybrid_values[target] = _coerce_numeric(value, key) if target != "use_home_indicator" else bool(value)
+
+    home_advantage = _coerce_numeric(source.get("home_advantage", HYBRID_DEFAULTS["home_advantage"]), "home_advantage")
+
+    matchup_values: dict[str, Any] = {}
+    for key, value in source.items():
+        target = _MATCHUP_ALIASES.get(key, key)
+        if target in matchup_keys:
+            matchup_values[target] = _coerce_numeric(value, key)
+
+    # Persisted home_advantage is treated as a numeric prior strength for the Poisson home term.
+    matchup_values.setdefault("home_advantage_ridge", home_advantage)
+
+    return HybridRankingConfig(**hybrid_values), MatchupModelConfig(**matchup_values)

--- a/tests/test_model_params_module.py
+++ b/tests/test_model_params_module.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from config.model_params import resolve_hybrid_and_matchup_configs
+
+
+def test_resolve_aliases_and_home_advantage_mapping():
+    hybrid_cfg, matchup_cfg = resolve_hybrid_and_matchup_configs(
+        {
+            "epsilon": 1e-4,
+            "margin_scale_s": 2.5,
+            "poisson_regularization": 0.75,
+            "home_advantage": 0.33,
+        }
+    )
+
+    assert hybrid_cfg.eps == pytest.approx(1e-4)
+    assert hybrid_cfg.margin_scale == pytest.approx(2.5)
+    assert matchup_cfg.ridge_lambda == pytest.approx(0.75)
+    assert matchup_cfg.home_advantage_ridge == pytest.approx(0.33)
+
+
+def test_resolve_defaults_when_params_missing():
+    hybrid_cfg, matchup_cfg = resolve_hybrid_and_matchup_configs({})
+
+    assert hybrid_cfg.eps == pytest.approx(1e-6)
+    assert hybrid_cfg.margin_scale == pytest.approx(4.0)
+    assert matchup_cfg.ridge_lambda == pytest.approx(0.2)
+    assert matchup_cfg.home_advantage_ridge == pytest.approx(0.1)
+
+
+def test_resolve_rejects_unknown_fields():
+    with pytest.raises(ValueError, match=r"Unknown config field\(s\): made_up"):
+        resolve_hybrid_and_matchup_configs({"made_up": 1})
+
+
+def test_resolve_rejects_malformed_numeric_field():
+    with pytest.raises(ValueError, match="must be numeric"):
+        resolve_hybrid_and_matchup_configs({"epsilon": "not-a-number"})


### PR DESCRIPTION
### Motivation
- Persisted configs and legacy keys do not map cleanly to current `HybridRankingConfig` and `MatchupModelConfig` dataclasses, and ad-hoc parsing scattered across the codebase produces inconsistent behavior and unclear error messages.

### Description
- Added `resolve_hybrid_and_matchup_configs` in `config/model_params.py` to map persisted keys (including legacy aliases) into typed `HybridRankingConfig` and `MatchupModelConfig` instances.
- Implemented backward-compatible aliases: `epsilon -> eps`, `margin_scale_s -> margin_scale`, and `poisson_regularization -> MatchupModelConfig.ridge_lambda`, and mapped persisted `home_advantage` into numeric `MatchupModelConfig.home_advantage_ridge` (a Poisson home-effect prior/regularizer).
- Added strict numeric coercion and finite-value validation with actionable errors for malformed numeric fields, plus explicit unknown-field rejection with guidance on supported aliases.
- Added unit tests in `tests/test_model_params_module.py` that cover alias resolution, defaults, unknown-field rejection, and malformed numeric input.

### Testing
- Ran `pytest tests/test_model_params_module.py tests/test_hybrid_ranking_module.py tests/test_ranking_module.py tests/test_parsing_module.py tests/test_stats_module.py` and observed all tests pass (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51ca9c268832c9d917ff666ae0772)