### PR TITLE
domain: attenuate weak-opponent SOV contributions

### DIFF
--- a/domain/hybrid_ranking.py
+++ b/domain/hybrid_ranking.py
@@ -271,23 +271,40 @@ class ScheduleAdjustedGoalStrengthRanker:
     def _compute_sov(self, games: pd.DataFrame, residuals: np.ndarray, theta: np.ndarray, team_to_idx: Dict[str, int]) -> np.ndarray:
         n_teams = len(team_to_idx)
         sov_sum = np.zeros(n_teams, dtype=float)
-        win_count = np.zeros(n_teams, dtype=float)
+        effective_weighted_wins = np.zeros(n_teams, dtype=float)
+
+        # Bound opponent quality in [0, 1] so repeated wins over weak opponents
+        # cannot overwhelm fewer surprise wins over stronger opposition.
+        median_theta = float(np.median(theta))
+        theta_std = float(np.std(theta))
+        quality_scale = max(theta_std, self.config.eps)
+
+        def bounded_quality(opponent_theta: float) -> float:
+            normalized = (opponent_theta - median_theta) / quality_scale
+            return float(1.0 / (1.0 + np.exp(-normalized)))
 
         for g_idx, row in games.reset_index(drop=True).iterrows():
             a = team_to_idx[row["team_a"]]
             b = team_to_idx[row["team_b"]]
-            quality_a = max(theta[b], 0.0)
-            quality_b = max(theta[a], 0.0)
+            quality_a = bounded_quality(theta[b])
+            quality_b = bounded_quality(theta[a])
             res = residuals[g_idx]
 
             if row["goals_a"] > row["goals_b"] and res > 0:
-                sov_sum[a] += res * (1.0 + quality_a)
-                win_count[a] += 1
+                game_weight = (0.25 + quality_a) ** 2
+                sov_sum[a] += res * game_weight
+                effective_weighted_wins[a] += game_weight
             elif row["goals_b"] > row["goals_a"] and -res > 0:
-                sov_sum[b] += (-res) * (1.0 + quality_b)
-                win_count[b] += 1
+                game_weight = (0.25 + quality_b) ** 2
+                sov_sum[b] += (-res) * game_weight
+                effective_weighted_wins[b] += game_weight
 
-        return np.divide(sov_sum, win_count, out=np.zeros_like(sov_sum), where=win_count > 0)
+        return np.divide(
+            sov_sum,
+            effective_weighted_wins,
+            out=np.zeros_like(sov_sum),
+            where=effective_weighted_wins > 0,
+        )
 
     def _compute_volatility(self, games: pd.DataFrame, residuals: np.ndarray, team_to_idx: Dict[str, int]) -> np.ndarray:
         n_teams = len(team_to_idx)

--- a/tests/test_hybrid_ranking_module.py
+++ b/tests/test_hybrid_ranking_module.py
@@ -73,6 +73,55 @@ def test_sov_rewards_quality_residual_more_than_weak_expected_blowout():
     assert sov["Hero"] > sov["Strong"]
 
 
+def test_sov_repeated_weak_wins_do_not_beat_fewer_high_surprise_strong_wins():
+    games = pd.DataFrame(
+        [
+            {"team_a": "Power", "team_b": "WeakA", "goals_a": 1, "goals_b": 0, "venue": "neutral"},
+            {"team_a": "Power", "team_b": "WeakB", "goals_a": 1, "goals_b": 0, "venue": "neutral"},
+            {"team_a": "Power", "team_b": "WeakC", "goals_a": 1, "goals_b": 0, "venue": "neutral"},
+            {"team_a": "Power", "team_b": "WeakD", "goals_a": 1, "goals_b": 0, "venue": "neutral"},
+            {"team_a": "Power", "team_b": "WeakE", "goals_a": 1, "goals_b": 0, "venue": "neutral"},
+            {"team_a": "Upset", "team_b": "Power", "goals_a": 1, "goals_b": 0, "venue": "neutral"},
+            {"team_a": "Upset", "team_b": "Power", "goals_a": 1, "goals_b": 0, "venue": "neutral"},
+        ]
+    )
+    teams = sorted(set(games["team_a"]).union(games["team_b"]))
+    team_to_idx = {team: idx for idx, team in enumerate(teams)}
+    theta = np.array([1.5 if team == "Power" else (-1.0 if team.startswith("Weak") else 0.0) for team in teams], dtype=float)
+    residuals = np.array([0.08, 0.09, 0.10, 0.08, 0.09, 0.45, 0.40], dtype=float)
+
+    ranker = ScheduleAdjustedGoalStrengthRanker(HybridRankingConfig())
+    sov = ranker._compute_sov(games, residuals=residuals, theta=theta, team_to_idx=team_to_idx)
+
+    assert sov[team_to_idx["Upset"]] > sov[team_to_idx["Power"]]
+
+
+def test_sov_is_non_negative_and_stable_with_duplicated_weak_games():
+    base_games = pd.DataFrame(
+        [
+            {"team_a": "Power", "team_b": "WeakA", "goals_a": 1, "goals_b": 0, "venue": "neutral"},
+            {"team_a": "Power", "team_b": "WeakB", "goals_a": 1, "goals_b": 0, "venue": "neutral"},
+            {"team_a": "Upset", "team_b": "Power", "goals_a": 1, "goals_b": 0, "venue": "neutral"},
+        ]
+    )
+    duplicated_games = pd.concat([base_games, base_games.iloc[[0, 1]]], ignore_index=True)
+
+    teams = sorted(set(duplicated_games["team_a"]).union(duplicated_games["team_b"]))
+    team_to_idx = {team: idx for idx, team in enumerate(teams)}
+    theta = np.array([1.5 if team == "Power" else (-1.0 if team.startswith("Weak") else 0.0) for team in teams], dtype=float)
+
+    base_residuals = np.array([0.1, 0.1, 0.4], dtype=float)
+    duplicated_residuals = np.array([0.1, 0.1, 0.4, 0.1, 0.1], dtype=float)
+
+    ranker = ScheduleAdjustedGoalStrengthRanker(HybridRankingConfig())
+    base_sov = ranker._compute_sov(base_games, residuals=base_residuals, theta=theta, team_to_idx=team_to_idx)
+    duplicated_sov = ranker._compute_sov(duplicated_games, residuals=duplicated_residuals, theta=theta, team_to_idx=team_to_idx)
+
+    assert (base_sov >= 0).all()
+    assert (duplicated_sov >= 0).all()
+    assert abs(duplicated_sov[team_to_idx["Power"]] - base_sov[team_to_idx["Power"]]) < 1e-9
+
+
 def test_uncertainty_bounds_and_ci_are_sensible():
     games = _load_hybrid_games()
     model = ScheduleAdjustedGoalStrengthRanker().fit(games)


### PR DESCRIPTION
### Motivation
- The existing SOV calculation could be dominated by raw counts of wins versus weak opponents, making volume beat surprise quality. 
- Introduce a bounded opponent-quality transform and per-team normalization so SOV emphasizes win surprise against stronger opponents rather than raw win volume. 

### Description
- Updated `ScheduleAdjustedGoalStrengthRanker._compute_sov(...)` in `domain/hybrid_ranking.py` to apply a logistic-bounded quality transform computed from median/std-normalized opponent `theta` values. 
- Each qualifying win is weighted by a bounded per-game weight `(0.25 + quality)^2` so weak-opponent wins are attenuated while higher-quality wins retain impact. 
- Replaced plain win-count normalization with per-team `effective_weighted_wins` to prevent raw game volume from dominating SOV. 
- Added fixture-driven tests in `tests/test_hybrid_ranking_module.py` that verify repeated weak-opposition wins do not outperform fewer high-surprise wins and that SOV is non-negative and stable under duplicated weak games. 

### Testing
- Ran `pytest tests/test_hybrid_ranking_module.py tests/test_ranking_module.py tests/test_parsing_module.py tests/test_stats_module.py` and observed all tests passing. 
- Test summary: `22 passed` (including the new SOV fixtures). 
- No automated tests failed during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51d5d7460832ca40247f8d5d46b2b)