### PR TITLE
domain: harden hybrid confidence baseline

### DIFF
--- a/domain/hybrid_ranking.py
+++ b/domain/hybrid_ranking.py
@@ -89,8 +89,18 @@ class ScheduleAdjustedGoalStrengthRanker:
         covariance = sigma2 * lhs_inv
         rating_se = np.sqrt(np.clip(np.diag(covariance)[:n_teams], a_min=0.0, a_max=None))
 
-        se_prior = self._se_prior()
-        confidence = np.clip(100.0 * (1.0 - (rating_se / se_prior)), 0.0, 100.0)
+        confidence_baseline_se = self._confidence_baseline_se(
+            rating_se=rating_se,
+            games_played=games_played,
+            lhs_inv=lhs_inv,
+            n_teams=n_teams,
+        )
+        # Confidence maps uncertainty to [0, 100] using a robust baseline SE.
+        # Formula: confidence_i = clip(100 * (1 - se_i / se_baseline), 0, 100).
+        # se_baseline uses the median SE among teams at the minimum information level
+        # (fewest games played), with a closed-form prior-only diagonal fallback
+        # sqrt(1 / ridge_lambda) when data geometry is singular or degenerate.
+        confidence = np.clip(100.0 * (1.0 - (rating_se / confidence_baseline_se)), 0.0, 100.0)
 
         sos = self._compute_sos(games, theta[:n_teams], team_to_idx, weights)
         lambda_sos = self.config.lambda_sos_max * (games_played / (games_played + self.config.k0))
@@ -215,6 +225,31 @@ class ScheduleAdjustedGoalStrengthRanker:
         if self.config.ridge_lambda <= 0:
             return 1.0
         return float(np.sqrt(1.0 / self.config.ridge_lambda))
+
+    def _confidence_baseline_se(
+        self,
+        rating_se: np.ndarray,
+        games_played: np.ndarray,
+        lhs_inv: np.ndarray,
+        n_teams: int,
+    ) -> float:
+        min_games = float(np.min(games_played))
+        min_info_mask = games_played == min_games
+        min_info_ses = rating_se[min_info_mask]
+        finite_min_info_ses = min_info_ses[np.isfinite(min_info_ses)]
+        if finite_min_info_ses.size > 0:
+            baseline = float(np.median(finite_min_info_ses))
+            if baseline > self.config.eps:
+                return baseline
+
+        prior_only_diag = np.diag(lhs_inv)[:n_teams]
+        finite_prior_diag = prior_only_diag[np.isfinite(prior_only_diag) & (prior_only_diag > 0.0)]
+        if finite_prior_diag.size > 0:
+            prior_closed_form = float(np.median(np.sqrt(finite_prior_diag)))
+            if prior_closed_form > self.config.eps:
+                return prior_closed_form
+
+        return max(self._se_prior(), self.config.eps)
 
     def _validate_schema(self, games_df: pd.DataFrame) -> None:
         missing = self.REQUIRED_COLUMNS - set(games_df.columns)

--- a/tests/test_hybrid_ranking_module.py
+++ b/tests/test_hybrid_ranking_module.py
@@ -188,3 +188,43 @@ def test_predict_matchup_schema_and_deterministic_scoreline_ordering():
         prev_key = (-prev["probability"], prev["score_a"], prev["score_b"])
         curr_key = (-curr["probability"], curr["score_a"], curr["score_b"])
         assert prev_key <= curr_key
+
+
+def test_confidence_increases_with_more_games_for_similar_signal():
+    games = pd.DataFrame(
+        [
+            {"team_a": "Low", "team_b": "OppA", "goals_a": 2, "goals_b": 1, "venue": "neutral"},
+            {"team_a": "High", "team_b": "OppB", "goals_a": 2, "goals_b": 1, "venue": "neutral"},
+            {"team_a": "High", "team_b": "OppC", "goals_a": 2, "goals_b": 1, "venue": "neutral"},
+            {"team_a": "High", "team_b": "OppD", "goals_a": 2, "goals_b": 1, "venue": "neutral"},
+        ]
+    )
+    model = ScheduleAdjustedGoalStrengthRanker().fit(games)
+    table = model.rankings_table().set_index("team")
+
+    assert table.loc["Low", "games"] < table.loc["High", "games"]
+    assert table.loc["Low", "confidence"] < table.loc["High", "confidence"]
+
+
+def test_confidence_is_strictly_bounded_between_0_and_100_under_extreme_settings():
+    games = _load_hybrid_games()
+    model = ScheduleAdjustedGoalStrengthRanker(HybridRankingConfig(ridge_lambda=1e-6, k0=1e6)).fit(games)
+    confidence = model.rankings_table()["confidence"]
+
+    assert (confidence >= 0.0).all()
+    assert (confidence <= 100.0).all()
+
+
+def test_confidence_has_no_nan_with_pseudoinverse_fallback_on_singular_design():
+    games = pd.DataFrame(
+        [
+            {"team_a": "A", "team_b": "B", "goals_a": 1, "goals_b": 0, "venue": "neutral"},
+            {"team_a": "A", "team_b": "B", "goals_a": 1, "goals_b": 0, "venue": "neutral"},
+        ]
+    )
+    model = ScheduleAdjustedGoalStrengthRanker(HybridRankingConfig(ridge_lambda=0.0)).fit(games)
+    table = model.rankings_table()
+
+    assert model.solve_used_pinv_
+    assert table["confidence"].notna().all()
+    assert np.isfinite(table["confidence"]).all()


### PR DESCRIPTION
### Motivation
- The previous confidence denominator was a fixed prior-only SE which can be brittle and poorly calibrated to the actual information in fitted data. 
- A data-aware baseline that reflects the minimum-information cohort avoids pathological confidence values (NaN/inf) under singular or degenerate designs. 
- Maintain existing uncertainty outputs (`rating_se`, `rating_ci_low`, `rating_ci_high`) while making the confidence score more robust and interpretable. 

### Description
- Replaced the fixed denominator in the `fit()` confidence computation with a new helper `def _confidence_baseline_se(...)` that first uses the median `rating_se` among teams with the fewest games. 
- Added fallbacks in `_confidence_baseline_se` to a closed-form prior-oriented diagonal estimate from `lhs_inv` and then to the prior-only `sqrt(1 / ridge_lambda)` (with an epsilon floor) to avoid degenerate divisions. 
- Kept `rating_se`, `rating_ci_low`, and `rating_ci_high` unchanged, retained clipping of `confidence` to `[0, 100]`, and added inline comments documenting the formula and fallback behavior near the confidence computation. 
- Added three unit tests to `tests/test_hybrid_ranking_module.py` that assert monotonic confidence increase with more games, strict `[0,100]` bounds, and no NaN/inf under pseudo-inverse fallback. 

### Testing
- Ran `pytest tests/test_hybrid_ranking_module.py` which executed the hybrid ranking tests including the new cases and all tests passed. 
- Test run result: `15 passed` (no failures or regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51ef0c264832c94a1d4d35c58d602)