### PR TITLE
domain: add team resume builder and integrate into Team Profile

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -12,6 +12,7 @@ import altair as alt
 
 from domain.parsing import discover_score_files, is_skippable_line, load_parser_config, normalize_team_name, parse_game_line_anchored
 from domain.hybrid_ranking import HybridRankingConfig, ScheduleAdjustedGoalStrengthRanker
+from domain.service import build_team_resume
 
 # ---------------- Constants ---------------- #
 SCORES_CSV = "scores.csv"
@@ -2158,6 +2159,8 @@ def main():
         st.session_state["rank_table_sort_mode"] = DEFAULT_SORT_MODE
     if st.session_state.get("team_selector_sort_mode") in LEGACY_METRIC_DEFAULTS or st.session_state.get("team_selector_sort_mode") == "Ensemble rank":
         st.session_state["team_selector_sort_mode"] = DEFAULT_SORT_MODE
+    bcar_scores = dict(zip(bcar_table["Team"], bcar_table["BCAR Score"])) if not bcar_table.empty else {}
+
     # Team profile selection
     default_team = "Evanston"
     default_compare_team = "New Trier"
@@ -2185,6 +2188,7 @@ def main():
     if opp == te or opp not in teams:
         opp = compare_teams[0] if compare_teams else None
         st.session_state["selected_compare_team"] = opp
+    team_resume = build_team_resume(te, games_inferred, bcar_scores, stats, h2h, sos)
     # Compute individual ranks
     ranks = {}
     ranks['win']  = win_ord.index(te)+1 if te in win_ord else None
@@ -2355,6 +2359,23 @@ def main():
                 f"Confidence context — Games: {team_conf_row['Games Confidence']:.1f}/100 · SOS: {team_conf_row['SOS Confidence']:.1f}/100 · Composite: {team_conf_row['Composite Confidence']:.1f}/100 ({team_conf_row['Confidence Tier']})"
             )
         st.caption(f"Shared context: {te} vs {opp}")
+        st.markdown("**Team resume**")
+        resume_summary = team_resume["summary"]
+        r1, r2, r3, r4 = st.columns(4)
+        r1.metric("Record", resume_summary["record"])
+        r2.metric("Goal Diff", f"{resume_summary['goal_diff']:+d}")
+        r3.metric("Streak", resume_summary["notable_streak"])
+        r4.metric("Vs ranked", resume_summary["ranked_opponent_split"])
+
+        top_wins_df = pd.DataFrame(team_resume["top_wins"])
+        worst_losses_df = pd.DataFrame(team_resume["worst_losses"])
+        wcol, lcol = st.columns(2)
+        with wcol:
+            st.caption("Top wins")
+            st.dataframe(top_wins_df[["opponent", "team_score", "opp_score", "margin", "quality"]], use_container_width=True)
+        with lcol:
+            st.caption("Worst losses")
+            st.dataframe(worst_losses_df[["opponent", "team_score", "opp_score", "margin", "negative_impact"]], use_container_width=True)
         h = h2h.get((te,opp),{'wins':0,'games':0})
         st.markdown(f"**H2H**: {h['wins']}-{h['games']-h['wins']} in {h['games']} games")
         st.caption("Head-to-head explorer: watch margin trend and whether recent meetings differ from overall record.")

--- a/domain/service.py
+++ b/domain/service.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _quality_score(team: str, bcar_scores: dict[str, float], stats: dict[str, dict[str, Any]], sos: dict[str, float]) -> float:
+    if team in bcar_scores:
+        return float(bcar_scores[team])
+    win_pct = float(stats.get(team, {}).get("win_pct", 0.0))
+    sos_val = float(sos.get(team, 0.0))
+    return win_pct * 100.0 + sos_val * 10.0
+
+
+def _result_streak(games: list[dict[str, Any]]) -> str:
+    if not games:
+        return "N/A"
+    symbols = []
+    for g in games:
+        margin = g["margin"]
+        symbols.append("W" if margin > 0 else "L" if margin < 0 else "T")
+    last = symbols[-1]
+    cnt = 1
+    for s in reversed(symbols[:-1]):
+        if s != last:
+            break
+        cnt += 1
+    return f"{last}{cnt}"
+
+
+def build_team_resume(team, games_df, bcar_scores, stats, h2h, sos):
+    team_games: list[dict[str, Any]] = []
+    for row in games_df.itertuples(index=False):
+        if row.team1 != team and row.team2 != team:
+            continue
+        is_home_slot = row.team1 == team
+        opp = row.team2 if is_home_slot else row.team1
+        team_score = int(row.score1 if is_home_slot else row.score2)
+        opp_score = int(row.score2 if is_home_slot else row.score1)
+        margin = team_score - opp_score
+        quality = _quality_score(opp, bcar_scores, stats, sos)
+        team_games.append(
+            {
+                "opponent": opp,
+                "team_score": team_score,
+                "opp_score": opp_score,
+                "margin": margin,
+                "quality": quality,
+                "impact": quality + max(0, team_score - opp_score) * 0.05,
+                "negative_impact": quality + max(0, opp_score - team_score) * 0.1,
+            }
+        )
+
+    wins = [g for g in team_games if g["margin"] > 0]
+    losses = [g for g in team_games if g["margin"] < 0]
+
+    top_wins = sorted(
+        wins,
+        key=lambda g: (-g["quality"], -g["margin"], g["opponent"], g["team_score"], g["opp_score"]),
+    )[: max(3, min(len(wins), 5))]
+    worst_losses = sorted(
+        losses,
+        key=lambda g: (-g["negative_impact"], -g["margin"], g["opponent"], g["team_score"], g["opp_score"]),
+    )[: max(3, min(len(losses), 5))]
+
+    tstats = stats.get(team, {})
+    opponents = sorted({g["opponent"] for g in team_games if g["opponent"] in bcar_scores}, key=lambda t: (-bcar_scores[t], t))
+    ranked_w = ranked_l = ranked_t = 0
+    for opp in opponents:
+        rec = h2h.get((team, opp), {"wins": 0, "games": 0})
+        ranked_w += int(rec.get("wins", 0))
+        ranked_g = int(rec.get("games", 0))
+        ranked_l += max(ranked_g - int(rec.get("wins", 0)), 0)
+    ranked_t = max(len([g for g in team_games if g["opponent"] in set(opponents)]) - ranked_w - ranked_l, 0)
+
+    summary = {
+        "record": f"{int(tstats.get('wins', 0))}-{int(tstats.get('losses', 0))}-{int(tstats.get('ties', 0))}",
+        "goal_diff": int(tstats.get("gd", 0)),
+        "notable_streak": _result_streak(team_games),
+        "ranked_opponent_split": f"{ranked_w}-{ranked_l}-{ranked_t}",
+    }
+
+    return {
+        "team": team,
+        "top_wins": top_wins,
+        "worst_losses": worst_losses,
+        "summary": summary,
+    }

--- a/tests/test_service_module.py
+++ b/tests/test_service_module.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+from domain.service import build_team_resume
+from domain.stats import compute_stats, compute_sos
+
+
+def test_build_team_resume_orders_wins_and_losses_deterministically():
+    games = pd.DataFrame(
+        [
+            {"team1": "A", "score1": 5, "team2": "B", "score2": 3},
+            {"team1": "A", "score1": 4, "team2": "C", "score2": 2},
+            {"team1": "A", "score1": 2, "team2": "D", "score2": 1},
+            {"team1": "A", "score1": 1, "team2": "E", "score2": 3},
+            {"team1": "A", "score1": 2, "team2": "F", "score2": 4},
+            {"team1": "A", "score1": 2, "team2": "G", "score2": 5},
+        ]
+    )
+    stats, h2h = compute_stats(games)
+    sos = compute_sos(stats)
+    bcar = {"B": 90.0, "C": 85.0, "D": 80.0, "E": 82.0, "F": 75.0}
+
+    resume = build_team_resume("A", games, bcar, stats, h2h, sos)
+
+    assert resume["summary"]["record"] == "3-3-0"
+    assert resume["summary"]["goal_diff"] == -2
+    assert resume["summary"]["notable_streak"] == "L3"
+    assert [w["opponent"] for w in resume["top_wins"]][:3] == ["B", "C", "D"]
+    assert [l["opponent"] for l in resume["worst_losses"]][:3] == ["G", "E", "F"]


### PR DESCRIPTION
### Motivation
- Provide a reusable, deterministic team "resume" model summarizing notable wins/losses and key summary stats for Team Profile and matchup context.
- Surface opponent-quality-aware highlights (BCAR primary, win_pct+SOS fallback) so UI context reflects opponent strength rather than raw margin alone.

### Description
- Added new domain service `build_team_resume(team, games_df, bcar_scores, stats, h2h, sos)` in `domain/service.py` that returns `top_wins`, `worst_losses`, and `summary` (fields: `record`, `goal_diff`, `notable_streak`, `ranked_opponent_split`).
- Implemented opponent quality scoring using BCAR when available and a fallback combining `win_pct` and `SOS` in `_quality_score`, and deterministic tie-break ordering in sorting keys for wins/losses.
- Integrated the resume into the UI by importing `build_team_resume` in `app/ui.py`, computing `team_resume` for the selected team, and rendering summary KPIs plus top-wins and worst-losses tables in the Team Profile and matchup views.
- Added unit test `tests/test_service_module.py` that validates deterministic ordering and summary values for a constructed fixture.

### Testing
- Ran the suite with `PYTHONPATH=. pytest tests/test_parsing_module.py tests/test_ranking_module.py tests/test_hybrid_ranking_module.py tests/test_stats_module.py tests/test_service_module.py`; outcome: all tests passed (`26 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52cf5d248832c8f579acf38673ed4)