### PR TITLE
app: remove public detail tabs from navigation

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -1952,17 +1952,41 @@ def build_primary_ranking_payload(teams, model_orders, stats, h2h, sos, team_imp
     }
 
 
+def get_primary_nav_options(is_admin_user):
+    nav_options = ["Rankings"]
+    if is_admin_user:
+        nav_options.append("Admin / Internal")
+    return nav_options
+
+
+def resolve_legacy_public_target(query_params, fallback_team=None):
+    legacy_value = ""
+    for key in ("tab", "section", "content_section", "primary_nav", "nav"):
+        raw = query_params.get(key)
+        if raw is None:
+            continue
+        legacy_value = str(raw).strip()
+        if legacy_value:
+            break
+    if not legacy_value:
+        return None
+
+    normalized = legacy_value.lower().replace("_", " ").strip()
+    if normalized in {"profile", "team profile", "teams"}:
+        return {"target_nav": "Rankings", "team": fallback_team}
+    if normalized in {"matchup insights", "matchups", "matchup"}:
+        return {"target_nav": "Rankings", "team": fallback_team}
+    return None
+
+
 def main():
     st.set_page_config(page_title="Polo Dashboard", layout="wide")
     is_deep_dive = str(st.query_params.get("debug_sectionals", "0")).strip().lower() in {"1", "true", "yes", "y"}
 
-    nav_options = ["Rankings", "Team Profile", "Matchup Insights"]
-    if _is_admin_user():
-        nav_options.append("Admin / Internal")
+    is_admin = _is_admin_user()
+    nav_options = get_primary_nav_options(is_admin)
     nav_labels = {
         "Rankings": "Rankings",
-        "Team Profile": "Teams",
-        "Matchup Insights": "Matchups",
         "Admin / Internal": "Admin",
     }
     if "primary_nav" not in st.session_state or st.session_state["primary_nav"] not in nav_options:
@@ -2386,7 +2410,15 @@ def main():
     ranks['elo']  = elo_ord.index(te)+1 if te in elo_ord else None
     ranks_list   = [v for v in ranks.values() if v]
     r_avg = round(sum(ranks_list)/len(ranks_list),2) if ranks_list else None
-    
+    legacy_target = resolve_legacy_public_target(st.query_params, fallback_team=te)
+    if legacy_target:
+        st.session_state["primary_nav"] = legacy_target["target_nav"]
+        if legacy_target.get("team"):
+            st.session_state["selected_team"] = legacy_target["team"]
+            st.query_params["team"] = legacy_target["team"]
+        st.query_params["primary_nav"] = legacy_target["target_nav"]
+        st.query_params["redirected_from"] = "legacy_public_tab"
+        st.rerun()
 
     # Tabs & content
     if current_nav == "Rankings":

--- a/tests/test_ui_navigation_module.py
+++ b/tests/test_ui_navigation_module.py
@@ -1,0 +1,21 @@
+from app.ui import get_primary_nav_options, resolve_legacy_public_target
+
+
+def test_public_nav_has_no_section_tabs():
+    nav = get_primary_nav_options(is_admin_user=False)
+    assert nav == ["Rankings"]
+    assert "Team Profile" not in nav
+    assert "Matchup Insights" not in nav
+
+
+def test_admin_nav_keeps_internal_access():
+    nav = get_primary_nav_options(is_admin_user=True)
+    assert nav == ["Rankings", "Admin / Internal"]
+
+
+def test_legacy_public_sections_redirect_to_rankings():
+    profile_redirect = resolve_legacy_public_target({"section": "Profile"}, fallback_team="Evanston")
+    matchup_redirect = resolve_legacy_public_target({"primary_nav": "Matchup Insights"}, fallback_team="Evanston")
+    assert profile_redirect == {"target_nav": "Rankings", "team": "Evanston"}
+    assert matchup_redirect == {"target_nav": "Rankings", "team": "Evanston"}
+


### PR DESCRIPTION
### Motivation
- Simplify the public UI by removing secondary sectional detail tabs (Team Profile / Matchup Insights) from public navigation while keeping canonical public rankings visible.
- Ensure legacy public URLs that referenced removed tabs do not become dead links by redirecting them to the canonical public destination.
- Preserve admin/internal access to the detailed sections and keep backend data endpoints intact for internal use.

### Description
- Replace ad-hoc nav assembly with `get_primary_nav_options(is_admin_user)` and use it in `main()` so public users only receive `Rankings` while admin users keep `Admin / Internal`.
- Introduce `resolve_legacy_public_target(query_params, fallback_team=None)` to detect legacy tab/section query params and map them to `Rankings`, preserving a selected team where available and setting `redirected_from` metadata before calling `st.rerun()`.
- Integrate the redirect resolution into the UI flow so legacy public links route to the canonical page instead of exposing removed tabs, while leaving internal rendering code unchanged behind admin gating.
- Add regression tests in `tests/test_ui_navigation_module.py` to assert public nav contains only `Rankings`, admin nav retains `Admin / Internal`, and legacy section query params redirect to `Rankings`.

### Testing
- Ran the test suite with module path fixed via `PYTHONPATH=.`: `PYTHONPATH=. pytest tests/test_ui_navigation_module.py tests/test_parsing_module.py tests/test_ranking_module.py tests/test_hybrid_ranking_module.py tests/test_stats_module.py tests/test_ui_smoke_module.py` and all tests passed (`30 passed`).
- An initial `pytest` run failed during collection due to the test environment not having `PYTHONPATH` set, which was resolved by the above command and re-run that succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a2529b54832c8453a1aac1c82212)