### PR TITLE
domain: add BCAR standing narrative guardrails

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -178,6 +178,8 @@ def render_team_explainer_card(card):
     c1, c2 = st.columns(2)
     c1.metric("Confidence", card["confidence_label"])
     c2.metric("Recency", card["recency_label"])
+    if card.get("standing_narrative"):
+        st.info(card["standing_narrative"])
     explainer_df = pd.DataFrame(card["factors"]).rename(columns={"name": "Factor", "value": "Score", "summary": "What this means"})
     st.dataframe(explainer_df[["Factor", "Score", "What this means"]], use_container_width=True, hide_index=True)
 def apply_chart_theme(chart):

--- a/domain/service.py
+++ b/domain/service.py
@@ -125,6 +125,30 @@ def _clamp_0_100(value: float) -> float:
     return max(0.0, min(100.0, float(value)))
 
 
+def _trend_bucket(recent_form_score: float) -> str:
+    if recent_form_score >= 60:
+        return "rising"
+    if recent_form_score <= 40:
+        return "falling"
+    return "flat"
+
+
+def _build_standing_narrative(team: str, bcar_rank: int | None, bcar_total: int | None, trend_label: str, resume_signal: str, as_of_utc: str) -> str:
+    if bcar_rank is not None and bcar_total is not None and bcar_total > 0:
+        position_sentence = f"{team} is currently #{bcar_rank} in BCAR out of {bcar_total} teams."
+    else:
+        position_sentence = f"{team} has a BCAR profile in progress with position still stabilizing."
+
+    trend_sentence = {
+        "rising": "Recent BCAR direction is rising based on current form and game outcomes.",
+        "flat": "Recent BCAR direction is flat, with no clear week-to-week shift.",
+        "falling": "Recent BCAR direction is falling based on recent outcomes.",
+    }[trend_label]
+
+    resume_sentence = f"Resume signal is {resume_signal}. Data refreshed: {as_of_utc} UTC."
+    return " ".join([position_sentence, trend_sentence, resume_sentence])
+
+
 def build_team_explainer_card(team: str, stats: dict[str, dict[str, Any]], sos: dict[str, float], h2h: dict[tuple[str, str], dict[str, int]], team_imputation: dict[str, dict[str, int]], as_of: datetime | None = None) -> dict[str, Any]:
     team_stats = stats.get(team, {})
     games = int(team_stats.get("games", 0))
@@ -162,7 +186,12 @@ def build_team_explainer_card(team: str, stats: dict[str, dict[str, Any]], sos: 
         if name == "Consistency":
             return "Game-to-game performance has been steady." if value >= 60 else "Performance has been volatile week to week."
         if name == "Recent form":
-            return "Recent form is trending up." if value >= 60 else "Recent form is neutral or down."
+            trend = _trend_bucket(value)
+            if trend == "rising":
+                return "Recent form is rising."
+            if trend == "falling":
+                return "Recent form is falling."
+            return "Recent form is flat."
         return "Coverage is broad enough to trust comparisons." if value >= 60 else "Coverage is thin; treat rank as provisional."
     factors = [
         {"name": "Results quality", "value": round(results_quality, 1)},
@@ -174,4 +203,18 @@ def build_team_explainer_card(team: str, stats: dict[str, dict[str, Any]], sos: 
     for factor in factors:
         factor["summary"] = statement(factor["name"], factor["value"])
     as_of_ts = as_of or datetime.now(timezone.utc)
-    return {"team": team, "factors": factors, "confidence_label": confidence, "recency_label": freshness, "as_of_utc": as_of_ts.isoformat(), "record": f"{wins}-{losses}-{ties}"}
+    trend_label = _trend_bucket(recent_form_score)
+    bcar_rank = team_stats.get("bcar_rank")
+    bcar_total = team_stats.get("bcar_total")
+    resume_signal = "strong" if (results_quality >= 65 and schedule_strength >= 60) else ("developing" if results_quality >= 50 else "mixed")
+    as_of_utc = as_of_ts.isoformat()
+    narrative = _build_standing_narrative(team, bcar_rank, bcar_total, trend_label, resume_signal, as_of_utc)
+    return {
+        "team": team,
+        "factors": factors,
+        "confidence_label": confidence,
+        "recency_label": freshness,
+        "as_of_utc": as_of_utc,
+        "record": f"{wins}-{losses}-{ties}",
+        "standing_narrative": narrative,
+    }

--- a/tests/test_service_explainer_module.py
+++ b/tests/test_service_explainer_module.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from datetime import datetime, timezone
 
 from domain.service import build_team_explainer_card
 from domain.stats import compute_stats, compute_sos
@@ -33,3 +34,21 @@ def test_explainer_sparse_history_sets_low_confidence():
     card = build_team_explainer_card("A", stats, sos, h2h, {"A": {"imputed": 1, "games": 1}})
     assert card["confidence_label"] == "Low"
     assert card["recency_label"] == "Early sample"
+
+
+def test_explainer_standing_narrative_contains_timestamp_and_flat_guardrail():
+    games = pd.DataFrame([
+        {"team1": "A", "score1": 2, "team2": "B", "score2": 2},
+        {"team1": "A", "score1": 1, "team2": "C", "score2": 1},
+    ])
+    stats, h2h = compute_stats(games)
+    stats["A"]["bcar_rank"] = 4
+    stats["A"]["bcar_total"] = 16
+    sos = compute_sos(stats)
+    as_of = datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc)
+    card = build_team_explainer_card("A", stats, sos, h2h, {"A": {"imputed": 0, "games": 2}}, as_of=as_of)
+
+    assert "#4 in BCAR out of 16 teams" in card["standing_narrative"]
+    assert "direction is flat" in card["standing_narrative"]
+    assert "trending up" not in card["standing_narrative"]
+    assert "2026-05-03T12:00:00+00:00 UTC" in card["standing_narrative"]


### PR DESCRIPTION
### Motivation
- Provide a short (2–3 sentence) plain-language standing summary for coaches, players, and parents that is grounded in computed metrics and avoids speculative wording.
- Surface BCAR position, recent trend, and a simple resume signal together with a data-freshness timestamp so readers can interpret statements correctly.
- Prevent contradictory language by deriving wording from an explicit trend bucket (`rising` / `flat` / `falling`).

### Description
- Added `_trend_bucket` and `_build_standing_narrative` helpers and integrated them into `build_team_explainer_card` to produce a `standing_narrative` string that includes BCAR position (when present), trend text, resume signal, and an `as_of` UTC timestamp.
- Replaced freeform recent-form wording with guarded text derived from `_trend_bucket` so factor summaries cannot contradict the computed trend.
- Updated the UI in `app/ui.py` to render the new `standing_narrative` block in the explainer card when present.
- Added a unit test in `tests/test_service_explainer_module.py` to assert that the narrative contains the BCAR position, includes the timestamp, and does not use rising language when the trend is `flat`.

### Testing
- Ran the full impacted test set with `PYTHONPATH=. pytest tests/test_service_explainer_module.py tests/test_parsing_module.py tests/test_ranking_module.py tests/test_hybrid_ranking_module.py tests/test_stats_module.py` and all tests passed (`29 passed`).
- An initial `pytest` run without `PYTHONPATH=.` failed at collection with `ModuleNotFoundError: No module named 'domain'`, which was resolved by setting `PYTHONPATH=.`, after which the suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a7c60d1c832c90d72419ce277e83)