### PR TITLE
app: restore required public top-level navigation

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -1974,7 +1974,7 @@ def build_primary_ranking_payload(teams, model_orders, stats, h2h, sos, team_imp
 
 
 def get_primary_nav_options(is_admin_user):
-    nav_options = ["Rankings"]
+    nav_options = ["Rankings", "Team Profiles/Resume", "Sectionals"]
     if is_admin_user:
         nav_options.append("Admin / Internal")
     return nav_options
@@ -1994,12 +1994,16 @@ def resolve_legacy_public_target(query_params, fallback_team=None):
 
     normalized = legacy_value.lower().replace("_", " ").strip()
     if normalized in {"profile", "team profile", "teams"}:
-        return {"target_nav": "Rankings", "team": fallback_team}
+        return {"target_nav": "Team Profiles/Resume", "team": fallback_team}
     if normalized in {"matchup insights", "matchups", "matchup"}:
-        return {"target_nav": "Rankings", "team": fallback_team}
+        return {"target_nav": "Sectionals", "team": fallback_team}
+    if normalized in {"team profiles/resume", "team profile/resume"}:
+        return {"target_nav": "Team Profiles/Resume", "team": fallback_team}
+    if normalized in {"sectionals"}:
+        return {"target_nav": "Sectionals", "team": fallback_team}
     if normalized.startswith("profile/") or normalized.startswith("team/"):
         team_slug = normalized.split("/", 1)[1].strip()
-        return {"target_nav": "Rankings", "team_slug": team_slug or None}
+        return {"target_nav": "Team Profiles/Resume", "team_slug": team_slug or None}
     return None
 
 
@@ -2049,6 +2053,8 @@ def main():
     nav_options = get_primary_nav_options(is_admin)
     nav_labels = {
         "Rankings": "Rankings",
+        "Team Profiles/Resume": "Team Profiles/Resume",
+        "Sectionals": "Sectionals",
         "Admin / Internal": "Admin",
     }
     if "primary_nav" not in st.session_state or st.session_state["primary_nav"] not in nav_options:
@@ -2578,27 +2584,35 @@ def main():
             st.caption("Public explainer only: internal tuning parameters are intentionally hidden.")
         return
 
+    if current_nav == "Team Profiles/Resume":
+        selected_section = "Profile"
+        st.query_params["section"] = selected_section
+        st.query_params["team"] = team_slug_lookup.get(te, te)
+    elif current_nav == "Sectionals":
+        selected_section = "Sectionals"
+        st.query_params["section"] = selected_section
+        st.query_params["team"] = team_slug_lookup.get(te, te)
+    else:
+        selected_section = None
+
     section_defaults = {
         "Rankings": "BCAR",
-        "Team Profile": "Profile",
-        "Matchup Insights": "Matchup Insights",
         "Admin / Internal": "Sectionals",
     }
-    all_sections = ["BCAR", "Profile", "Matchup Insights", "Sectionals", "Win%", "Pythag", "AdjPyth", "Elo", "Hybrid", "Ensemble (Primary)"]
+    all_sections = ["BCAR", "Profile", "Sectionals", "Win%", "Pythag", "AdjPyth", "Elo", "Hybrid", "Ensemble (Primary)"]
     available_sections = {
         "Rankings": ["BCAR"],
-        "Team Profile": ["Profile"],
-        "Matchup Insights": ["Matchup Insights"],
         "Admin / Internal": ["Sectionals", "Win%", "Pythag", "AdjPyth", "Elo", "Hybrid", "Ensemble (Primary)"],
     }.get(current_nav, all_sections)
-    default_section = section_defaults.get(current_nav, "BCAR")
-    if "content_section" not in st.session_state or st.session_state["content_section"] not in available_sections:
-        st.session_state["content_section"] = default_section if default_section in available_sections else available_sections[0]
-    st.markdown("### Content")
-    st.radio("View", options=available_sections, horizontal=True, key="content_section")
-    selected_section = st.session_state["content_section"]
-    st.query_params["section"] = selected_section
-    st.query_params["team"] = team_slug_lookup.get(te, te)
+    if selected_section is None:
+        default_section = section_defaults.get(current_nav, "BCAR")
+        if "content_section" not in st.session_state or st.session_state["content_section"] not in available_sections:
+            st.session_state["content_section"] = default_section if default_section in available_sections else available_sections[0]
+        st.markdown("### Content")
+        st.radio("View", options=available_sections, horizontal=True, key="content_section")
+        selected_section = st.session_state["content_section"]
+        st.query_params["section"] = selected_section
+        st.query_params["team"] = team_slug_lookup.get(te, te)
     table_sort_mode = st.session_state.get("rank_table_sort_mode", DEFAULT_SORT_MODE)
     if table_sort_mode in LEGACY_METRIC_DEFAULTS or table_sort_mode == "Ensemble rank":
         table_sort_mode = DEFAULT_SORT_MODE

--- a/tests/test_ui_navigation_module.py
+++ b/tests/test_ui_navigation_module.py
@@ -9,21 +9,25 @@ from app.ui import (
 
 def test_public_nav_has_no_section_tabs():
     nav = get_primary_nav_options(is_admin_user=False)
-    assert nav == ["Rankings"]
-    assert "Team Profile" not in nav
+    assert nav == ["Rankings", "Team Profiles/Resume", "Sectionals"]
     assert "Matchup Insights" not in nav
 
 
 def test_admin_nav_keeps_internal_access():
     nav = get_primary_nav_options(is_admin_user=True)
-    assert nav == ["Rankings", "Admin / Internal"]
+    assert nav == ["Rankings", "Team Profiles/Resume", "Sectionals", "Admin / Internal"]
 
 
-def test_legacy_public_sections_redirect_to_rankings():
+def test_legacy_public_sections_redirect_to_canonical_destinations():
     profile_redirect = resolve_legacy_public_target({"section": "Profile"}, fallback_team="Evanston")
     matchup_redirect = resolve_legacy_public_target({"primary_nav": "Matchup Insights"}, fallback_team="Evanston")
-    assert profile_redirect == {"target_nav": "Rankings", "team": "Evanston"}
-    assert matchup_redirect == {"target_nav": "Rankings", "team": "Evanston"}
+    assert profile_redirect == {"target_nav": "Team Profiles/Resume", "team": "Evanston"}
+    assert matchup_redirect == {"target_nav": "Sectionals", "team": "Evanston"}
+
+
+def test_primary_nav_presence_regression_guard():
+    nav = get_primary_nav_options(is_admin_user=False)
+    assert set(nav) == {"Rankings", "Team Profiles/Resume", "Sectionals"}
 
 
 def test_team_slug_lookup_is_stable_and_unique():


### PR DESCRIPTION
### Motivation
- Restore three required public top-level destinations (Rankings, Team Profiles/Resume, Sectionals) after a prior cleanup reduced the public IA to a single tab.
- Preserve existing public behavior with BCAR as the default ranking metric and keep secondary metrics collapsed by default.
- Ensure backward-compatible handling of legacy deep links so removed/old tabs are redirected to canonical public destinations instead of being dropped.
- Add a regression guard so required primary nav items cannot be accidentally removed by future cleanup.

### Description
- Reintroduced three public primary nav options in `get_primary_nav_options`: `"Rankings"`, `"Team Profiles/Resume"`, and `"Sectionals"`, while keeping `"Admin / Internal"` for admin users only (`app/ui.py`).
- Updated `resolve_legacy_public_target` to map legacy aliases to the new canonical destinations (profile/team -> `Team Profiles/Resume`, matchup -> `Sectionals`, and slugged `profile/...`/`team/...` -> `Team Profiles/Resume`) and preserved team slug handling (`app/ui.py`).
- Adjusted `main()` nav labels and routing so selecting `Team Profiles/Resume` and `Sectionals` sets the canonical `section`/`team` query params and bypasses the public sub-tab selector, while leaving Rankings behavior (BCAR default and collapsed secondary metrics) intact (`app/ui.py`).
- Added/updated tests in `tests/test_ui_navigation_module.py` to assert the three required public tabs, admin behavior, canonical legacy redirects, and a presence/regression guard (`test_primary_nav_presence_regression_guard`).

### Testing
- Ran the targeted test suite with `PYTHONPATH=. pytest -q tests/test_ui_navigation_module.py tests/test_ranking_module.py tests/test_hybrid_ranking_module.py tests/test_stats_module.py tests/test_parsing_module.py` and observed all tests passing.
- Outcome: `31 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7aad3dfc0832cbb0e65867c20cc50)