### PR TITLE
app: decouple team selector widget state from routing target

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -2463,16 +2463,33 @@ def main():
         selector_sort_mode, teams, stats, sos, primary_payload["table"], elo=elo, bcar_table=bcar_table, adj_vals=adj_vals, pyth_vals=py
     )
     default_team_index = selector_order.index(default_team) if default_team in selector_order else 0
-    if "selected_team" not in st.session_state or st.session_state["selected_team"] not in teams:
-        st.session_state["selected_team"] = selector_order[default_team_index]
+    if "selected_team_route_target" not in st.session_state:
+        st.session_state["selected_team_route_target"] = None
     team_slug_lookup = build_team_slug_lookup(teams)
     team_slug_reverse = {slug: team for team, slug in team_slug_lookup.items()}
     team_from_url = str(st.query_params.get("team", "")).strip()
+
+    valid_team_from_url = None
     if team_from_url in teams:
-        st.session_state["selected_team"] = team_from_url
+        valid_team_from_url = team_from_url
     elif team_from_url in team_slug_reverse:
-        st.session_state["selected_team"] = team_slug_reverse[team_from_url]
-    te = st.sidebar.selectbox("Select Team", selector_order, key="selected_team")
+        valid_team_from_url = team_slug_reverse[team_from_url]
+    if valid_team_from_url:
+        st.session_state["selected_team_route_target"] = valid_team_from_url
+
+    route_target_team = st.session_state.get("selected_team_route_target")
+    widget_default_team = selector_order[default_team_index]
+    if route_target_team in selector_order:
+        widget_default_team = route_target_team
+    elif st.session_state.get("selected_team_widget") in selector_order:
+        widget_default_team = st.session_state["selected_team_widget"]
+    st.session_state["selected_team_widget"] = widget_default_team
+
+    st.sidebar.selectbox("Select Team", selector_order, key="selected_team_widget")
+    te = st.session_state.get("selected_team_widget", widget_default_team)
+    st.session_state["selected_team"] = te
+    if route_target_team in selector_order:
+        st.session_state["selected_team_route_target"] = None
     compare_teams = [t for t in selector_order if t != te]
     if compare_teams:
         default_compare_index = compare_teams.index(default_compare_team) if default_compare_team in compare_teams else 0
@@ -2501,7 +2518,7 @@ def main():
         if legacy_target.get("team_slug") and legacy_target["team_slug"] in team_slug_reverse:
             legacy_target["team"] = team_slug_reverse[legacy_target["team_slug"]]
         if legacy_target.get("team"):
-            st.session_state["selected_team"] = legacy_target["team"]
+            st.session_state["selected_team_route_target"] = legacy_target["team"]
             st.query_params["team"] = legacy_target["team"]
         st.query_params["primary_nav"] = legacy_target["target_nav"]
         st.query_params["redirected_from"] = "legacy_public_tab"


### PR DESCRIPTION
### Motivation
- Prevent mutating widget-owned Streamlit session state after render to avoid unstable reruns and state exceptions when deep-linking or migrating legacy routes.
- Preserve legacy deep-linking/redirect behavior while making selection intent one-time and non-invasive to the widget control.
- Maintain downstream compatibility for code that expects a canonical `selected_team` value.

### Description
- Modified `app/ui.py` team-selection flow to introduce two keys: `selected_team_widget` (widget-owned key) and `selected_team_route_target` (routing/deep-link intent key) and initialize `selected_team_route_target` to `None` if missing.
- Apply route/deep-link intent before rendering the selectbox by computing a `widget_default_team` and setting `selected_team_widget` prior to calling `st.sidebar.selectbox(...)` so the widget is not mutated after render.
- After the widget renders, derive a canonical `selected_team` from the widget value for downstream logic and clear `selected_team_route_target` once consumed to avoid repeated reruns forcing selection.
- Replace direct writes to `selected_team` in legacy routing/migration code with writes to `selected_team_route_target` so legacy redirects signal intent without mutating the widget key.

### Testing
- Ran `PYTHONPATH=. pytest tests/test_ui_navigation_module.py` which passed: `6 passed`.
- Noted an initial environment import error when running `pytest tests/test_ui_navigation_module.py` without `PYTHONPATH=.`, which was an environment setup issue rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b27e3964832ca61b440ffc704073)